### PR TITLE
fix error when using shortcut and just a string as globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var watch = require('watch');
 var walker = require('walker');
-var platform = require('os').platform()
+var platform = require('os').platform();
 var minimatch = require('minimatch');
 var EventEmitter = require('events').EventEmitter;
 
@@ -42,7 +42,7 @@ function Watcher(dir, opts) {
     ? opts.persistent
     : true;
   this.globs = opts.glob || [];
-  if (!Array.isArray(this.globs)) this.globs = [this.glob];
+  if (!Array.isArray(this.globs)) this.globs = [this.globs];
   this.watched = Object.create(null);
   this.changeTimers = Object.create(null);
   this.dirRegistery = Object.create(null);

--- a/test/test.js
+++ b/test/test.js
@@ -34,7 +34,7 @@ function harness(isPolling) {
         fs.writeFileSync(jo(subdir, 'file_' + j), 'test_' + j);
       }
     }
-  })
+  });
 
   describe('sane(file)', function() {
     beforeEach(function () {
@@ -211,6 +211,27 @@ function harness(isPolling) {
         fs.writeFileSync(jo(testdir, 'file_9'), 'wow');
         fs.writeFileSync(jo(testdir, 'file_3'), 'wow');
         fs.writeFileSync(jo(testdir, 'file_2'), 'wow');
+      });
+    });
+  });
+
+  describe('sane shortcut alias', function () {
+    
+    beforeEach(function () {
+      this.watcher = sane(testdir, '**/file_1');
+    });
+
+    afterEach(function() {
+      this.watcher.close();
+    });
+
+    it('allows for shortcut mode using just a string as glob', function (done) { 
+      this.watcher.on('change', function (filepath) {
+        assert.ok(filepath.match(/file_1/));
+        done();
+      });
+      this.watcher.on('ready', function() {
+        fs.writeFileSync(jo(testdir, 'file_1'), 'wow');
       });
     });
   });


### PR DESCRIPTION
There was a minmatch error, when trying to use just a string as glob argument in the shortcut version. If this is intended, please feel free to ignore this PR.
