### PR TITLE
=BG= fix file path error (\ vs. /) that occurs on on some versions of Windows by using path.normalize

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,9 +241,9 @@ Watcher.prototype.close = function() {
 
 Watcher.prototype.detectChangedFile = function(dir, event, callback) {
   var found = false;
-  var closest = {mtime: 0}
+  var closest = {mtime: 0};
   var c = 0;
-  Object.keys(this.dirRegistery[dir]).forEach(function(file, i, arr) {
+  Object.keys(this.dirRegistery[path.normalize(dir)]).forEach(function(file, i, arr) {
     fs.stat(path.join(dir, file), function(error, stat) {
       if (found) return;
       if (error) {


### PR DESCRIPTION
```
c:\code\emp\node_modules\ember-cli\node_modules\broccoli-sane-watcher\node_modules\sane\index.js:245
  Object.keys(this.dirRegistery[dir]).forEach(function(file, i, arr) {
         ^    TypeError: Object.keys called on non-object
    at Function.keys (native)
    at Watcher.detectChangedFile (c:\code\emp\node_modules\ember-cli\node_modules\broccoli-sane-watcher\node_modules\sane\index.js:245:10)
    at Watcher.normalizeChange (c:\code\emp\node_modules\ember-cli\node_modules\broccoli-sane-watcher\node_modules\sane\index.js:279:10)
    at FSWatcher.emit (events.js:98:17)
    at FSEvent.FSWatcher._handle.onchange (fs.js:1044:12)
```

When I inspected `dir` and `dirRegistry` at this line of code, there appeared to be a mismatch between the keys of the `this.dirRegistery` object and the value of the `dir` string - the keys had backslashes (`\`) and dir contained forward slashes (`/`). Hence `path.normalize(dir)` fixed the problem.

I am unable to ascertain exactly what causes this, but I have no issues on Ubuntu 12.04 64bit, and Ubuntu 13.04 32bit, but run into issues on Windows 7 Pro 6.1.7601 64 bit - so it appears to be a Windows thing.
