### PR TITLE
=BG= Part 2: fix file path error (\ vs. /) that occurs on on some versions of Windows by using path.normalize

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,6 +276,7 @@ Watcher.prototype.detectChangedFile = function(dir, event, callback) {
  */
 
 Watcher.prototype.normalizeChange = function(dir, event, file) {
+  dir = path.normalize(dir);
   if (!file) {
     this.detectChangedFile(dir, event, function(actualFile) {
       if (actualFile) {


### PR DESCRIPTION
Follow up from https://github.com/amasad/sane/pull/14
