### PR TITLE
Include root directory in event callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Shortcut for `new sane.Watcher(dir, {glob: globs, ..options})`.
 ```js
 var watcher = sane('path/to/dir', ['**/*.js', '**/*.css']);
 watcher.on('ready', function () { console.log('ready') });
-watcher.on('change', function (filepath) { console.log('file changed', filepath); });
-watcher.on('add', function (filepath) { console.log('file added', filepath); });
-watcher.on('delete', function (filepath) { console.log('file deleted', filepath); });
+watcher.on('change', function (filepath, root) { console.log('file changed', filepath); });
+watcher.on('add', function (filepath, root) { console.log('file added', filepath); });
+watcher.on('delete', function (filepath, root) { console.log('file deleted', filepath); });
 // close
 watcher.close();
 ```

--- a/index.js
+++ b/index.js
@@ -343,7 +343,7 @@ Watcher.prototype.emitEvent = function(type, file) {
   clearTimeout(this.changeTimers[key]);
   this.changeTimers[key] = setTimeout(function() {
     delete this.changeTimers[key];
-    this.emit(type, file);
+    this.emit(type, file, this.root);
   }.bind(this), DEFAULT_DELAY);
 };
 
@@ -373,7 +373,7 @@ Watcher.prototype.initPoller = function(monitor) {
 
 Watcher.prototype.pollerEmit = function(type, file) {
   file = path.relative(this.root, file);
-  this.emit(type, file);
+  this.emit(type, file, this.root);
 };
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -51,8 +51,9 @@ function harness(isPolling) {
 
     it('change emits event', function(done) {
       var testfile = jo(testdir, 'file_1');
-      this.watcher.on('change', function(filepath) {
+      this.watcher.on('change', function(filepath, dir) {
         assert.equal(filepath, path.relative(testdir, testfile));
+        assert.equal(dir, testdir);
         done();
       });
       this.watcher.on('ready', function() {
@@ -62,8 +63,9 @@ function harness(isPolling) {
 
     it('emits change events for subdir files', function(done) {
       var testfile = jo(testdir, 'sub_1', 'file_1');
-      this.watcher.on('change', function(filepath) {
+      this.watcher.on('change', function(filepath, dir) {
         assert.equal(filepath, path.relative(testdir, testfile));
+        assert.equal(dir, testdir);
         done();
       });
       this.watcher.on('ready', function() {
@@ -73,8 +75,9 @@ function harness(isPolling) {
 
     it('adding a file will trigger a change', function(done) {
       var testfile = jo(testdir, 'file_x' + Math.floor(Math.random() * 10000));
-      this.watcher.on('add', function(filepath) {
+      this.watcher.on('add', function(filepath, dir) {
         assert.equal(filepath, path.relative(testdir, testfile));
+        assert.equal(dir, testdir);
         done();
       });
       this.watcher.on('ready', function() {
@@ -84,8 +87,9 @@ function harness(isPolling) {
 
     it('removing a file will emit delete event', function(done) {
       var testfile = jo(testdir, 'file_9');
-      this.watcher.on('delete', function(filepath) {
+      this.watcher.on('delete', function(filepath, dir) {
         assert.equal(filepath, path.relative(testdir, testfile));
+        assert.equal(dir, testdir);
         done();
       });
       this.watcher.on('ready', function() {
@@ -95,12 +99,13 @@ function harness(isPolling) {
 
     it('removing a dir will emit delete event', function(done) {
       var subdir = jo(testdir, 'sub_9');
-      this.watcher.on('delete', function(filepath) {
+      this.watcher.on('delete', function(filepath, dir) {
         // Ignore delete events for files in the dir.
         if (path.dirname(filepath) === path.relative(testdir, subdir)) {
           return;
         }
         assert.equal(filepath, path.relative(testdir, subdir));
+        assert.equal(dir, testdir);
         done();
       });
       this.watcher.on('ready', function() {
@@ -110,8 +115,9 @@ function harness(isPolling) {
 
     it('adding a dir will emit an add event', function(done) {
       var subdir = jo(testdir, 'sub_x' + Math.floor(Math.random() * 10000));
-      this.watcher.on('add', function(filepath) {
+      this.watcher.on('add', function(filepath, dir) {
         assert.equal(filepath, path.relative(testdir, subdir));
+        assert.equal(dir, testdir);
         done();
       });
       this.watcher.on('ready', function() {
@@ -123,11 +129,13 @@ function harness(isPolling) {
       var subdir = jo(testdir, 'sub_x' + Math.floor(Math.random() * 10000));
       var testfile = jo(subdir, 'file_x' + Math.floor(Math.random() * 10000));
       var i = 0;
-      this.watcher.on('add', function(filepath) {
+      this.watcher.on('add', function(filepath, dir) {
         if (++i === 1) {
           assert.equal(filepath, path.relative(testdir, subdir));
+          assert.equal(dir, testdir);
         } else {
           assert.equal(filepath, path.relative(testdir, testfile));
+          assert.equal(dir, testdir);
           done();
         }
       });
@@ -172,11 +180,13 @@ function harness(isPolling) {
     it('should be ok to remove and then add the same file', function(done) {
       var testfile = jo(testdir, 'sub_8', 'file_1');
       var i = 0;
-      this.watcher.on('add', function(filepath) {
+      this.watcher.on('add', function(filepath, dir) {
         assert.equal(filepath, path.relative(testdir, testfile));
+        assert.equal(dir, testdir);
       });
-      this.watcher.on('delete', function(filepath) {
+      this.watcher.on('delete', function(filepath, dir) {
         assert.equal(filepath, path.relative(testdir, testfile));
+        assert.equal(dir, testdir);
         done();
       });
       this.watcher.on('ready', function() {
@@ -202,8 +212,9 @@ function harness(isPolling) {
 
     it('ignore files according to glob', function (done) {
       var i = 0;
-      this.watcher.on('change', function(filepath) {
+      this.watcher.on('change', function(filepath, dir) {
         assert.ok(filepath.match(/file_(1|2)/), 'only file_1 and file_2');
+        assert.equal(dir, testdir);
         if (++i == 2) done();
       });
       this.watcher.on('ready', function() {
@@ -226,8 +237,9 @@ function harness(isPolling) {
     });
 
     it('allows for shortcut mode using just a string as glob', function (done) { 
-      this.watcher.on('change', function (filepath) {
+      this.watcher.on('change', function (filepath, dir) {
         assert.ok(filepath.match(/file_1/));
+        assert.equal(dir, testdir);
         done();
       });
       this.watcher.on('ready', function() {


### PR DESCRIPTION
If you have multiple watchers running the relative file path alone is
not enough to decide if an action should be taken or not. Including the
root path of the watcher provides more insight.

I have opted to add the root path as a 2nd argument to the event
callback so as to (hopefully) make this change backwards compatible.

ember-cli is using multiple watchers for many of the Broccoli trees. I have a use-case where I would like to filter out certain files from the watcher callbacks but require more information than just the relative filepath
