### PR TITLE
Update minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "fb-watchman": "0.0.0",
-    "minimatch": "~0.2.14",
+    "minimatch": "~2.0.1",
     "walker": "~1.0.5",
     "watch": "~0.10.0"
   },


### PR DESCRIPTION
It would be nice to use the latest version. I couldn't see if there were any reasons to sticking to the former API, but may have overlooked something, so please do double-check.
