### PR TITLE
fs.stat -> fs.lstat

### DIFF
--- a/src/watchman_watcher.js
+++ b/src/watchman_watcher.js
@@ -130,7 +130,7 @@ WatchmanWatcher.prototype.handleFileChange = function(changeDescriptor) {
   if (!changeDescriptor.exists) {
     self.emitEvent(DELETE_EVENT, changeDescriptor.name, self.root);
   } else {
-    fs.stat(absPath, function(error, stat) {
+    fs.lstat(absPath, function(error, stat) {
       if (handleError(self, error)) {
         return;
       }


### PR DESCRIPTION
See my comment on https://github.com/amasad/sane/issues/37#issuecomment-68813434
Watchman will not follow symlinks but will report the symlink nodes themselves.
This means that sane should use `lstat` to examine the filesystem; in cases where the symlink has become a dangling symlink a regular `stat` operation will fail because it will try to deference the broken symlink.  `lstat` will correctly identify the symlink.