### PR TITLE
Add ignore option to NodeWatcher

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -24,9 +24,13 @@ exports.ALL_EVENT = 'all';
 exports.assignOptions = function(watcher, opts) {
   opts = opts || {};
   watcher.globs = opts.glob || [];
+  watcher.ignore = opts.ignore || [];
   watcher.dot = opts.dot || false;
   if (!Array.isArray(watcher.globs)) {
     watcher.globs = [watcher.globs];
+  }
+  if (!Array.isArray(watcher.ignore)) {
+    watcher.ignore = [watcher.ignore];
   }
   return opts;
 };
@@ -40,10 +44,19 @@ exports.assignOptions = function(watcher, opts) {
  * @public
  */
 
-exports.isFileIncluded = function(globs, dot, relativePath) {
-  var matched;
+exports.isFileIncluded = function(globs, dot, ignore, relativePath) {
+  var matched = false;
+  var i;
+  var l;
+  if (ignore.length) {
+    for (i = 0, l = ignore.length; i < l; i++) {
+      if (minimatch(relativePath, ignore[i])) {
+        return false;
+      }
+    }
+  }
   if (globs.length) {
-    for (var i = 0; i < globs.length; i++) {
+    for (i = 0, l = globs.length; i < l; i++) {
       if (minimatch(relativePath, globs[i], {dot: dot})) {
         matched = true;
         break;

--- a/src/node_watcher.js
+++ b/src/node_watcher.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var walker = require('walker');
 var common = require('./common');
+var minimatch = require('minimatch');
 var platform = require('os').platform();
 var EventEmitter = require('events').EventEmitter;
 
@@ -335,8 +336,7 @@ function recReaddir(dir, ignore, dirCallback, fileCallback, endCallback) {
 
     dirWalker = dirWalker.filterDir(function (dir) {
       for (var i = 0, l = ignore.length; i < l; i++) {
-        var regex = new RegExp(ignore[i]);
-        if (regex.test(dir)) {
+        if (minimatch(dir, ignore[i])) {
           return false;
         }
         return true;

--- a/src/poll_watcher.js
+++ b/src/poll_watcher.js
@@ -60,6 +60,7 @@ PollWatcher.prototype.filter = function(filepath, stat) {
   return stat.isDirectory() || common.isFileIncluded(
     this.globs,
     this.dot,
+    this.ignore,
     path.relative(this.root, filepath)
   );
 };

--- a/src/watchman_watcher.js
+++ b/src/watchman_watcher.js
@@ -184,7 +184,7 @@ WatchmanWatcher.prototype.handleFileChange = function(changeDescriptor) {
   }
 
   var relativePath = path.relative(this.root, absPath);
-  if (!common.isFileIncluded(this.globs, this.dot, relativePath)) {
+  if (!common.isFileIncluded(this.globs, this.dot, this.ignore, relativePath)) {
     return;
   }
 

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,49 @@
+var assert = require('assert');
+var common = require('../src/common.js');
+
+context('common.js', function () {
+  context('isFileIncluded', function () {
+    var globs = ['./**/*'];
+    var ignore = ['./test/**/*'];
+
+    it('should match a single file', function () {
+      assert(common.isFileIncluded(
+        globs,
+        false,
+        [],
+        './package.json'
+      ));
+    });
+
+    it('should respect ignore patterns', function () {
+      assert(common.isFileIncluded(
+        globs,
+        false,
+        [],
+        './test/common.js'
+      ));
+      assert(!common.isFileIncluded(
+        globs,
+        false,
+        ignore,
+        './test/common.js'
+      ));
+    });
+
+    it('should accept the ./ when there are no globs only if dot is true', function() {
+      assert(!common.isFileIncluded(
+        [],
+        false,
+        [],
+        './'
+      ));
+
+      assert(common.isFileIncluded(
+        [],
+        true,
+        [],
+        './'
+      ));
+    });
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,7 @@ describe('sane in normal mode', function() {
   harness.call(this, {});
 });
 describe('sane in watchman mode', function() {
-  harness.call(this, {watchman: true})
+  harness.call(this, {watchman: true});
 });
 
 function getWatcherClass(mode) {


### PR DESCRIPTION
Add the simplest possible implementation of ignore option that allows not to watch directories that match
the given glob(s).

Added to allow to ignore the `node_modules` folder of React Native. It was causing an EMFILE error because it'd exceed the allowed number of open file descriptors on Travis CI.

Right now it was just implemented on `NodeWatcher` but I can add it to the other watchers if you think it's useful/necessary.

It currently supports: 
`new NodeWatcher('path/to/project', { ignore: 'node_modules' })`
`new NodeWatcher('path/to/project', { ignore: ['a', 'b', 'c'] })`
