### PR TITLE
Upgrade watchman watcher to take advantage of new features

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "exec-sh": "^0.2.0",
-    "fb-watchman": "^1.1.0",
+    "fb-watchman": "^1.5.0",
     "minimatch": "~0.2.14",
     "minimist": "^1.1.1",
     "walker": "~1.0.5",
@@ -33,7 +33,8 @@
   "devDependencies": {
     "jshint": "^2.5.10",
     "mocha": "~1.17.1",
-    "rimraf": "~2.2.6"
+    "rimraf": "~2.2.6",
+    "tmp": "0.0.27"
   },
   "engines": {
     "node": ">=0.6.0"


### PR DESCRIPTION
This bumps up the fb-watchman dependency to 1.5, the minimum required
version to:

* Eliminate the local `which watchman` check, which isn't portable
  to Windows.  fb-watchman 1.5 has improved handling for a missing
  watchman service and takes care of emitting an appropriate message
  and a link to the install page.
* Make use of the new capability checking API.  This makes it simpler
  to test for and use:
* wildmatch support on the watchman server.  Newer versions of watchman
  have enhanced globbing support that allow sane to offload the glob
  processing to the watchman server.  This makes subscriptions more
  efficient and reduces the compute work done in node.
* relative_root support.  Newer versions of watchman can do more of
  the tricky dirname stuff on the server side when we use watch-project.
  In fact, I removed the dirname stuff in favor of relative_root.
  I believe that FB are the only site where this really matters, and
  we're fully switched to versions that support relative_root.

In addition:

* fixed the plumbing for the 'error' event; it wasn't re-emitting
  errors from the watchman client to the sane watcher instance.
* Added a test mode where we positively assert that the relative_root
  stuff is working.
* Make a new tmp dir for each run of the harness, and clean it up
  at the end.  This is important because we want to ensure that
  any watchman watches are torn down at the end (happens when
  we remove the dir), and because we're now testing two different
  modes of watchman in the harness.
* Simplified the watcher.close method; the subscriptions are
  automatically cancelled when we close the client object.