### PR TITLE
Allow custom plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,14 @@ var PollWatcher = require('./src/poll_watcher');
 var WatchmanWatcher = require('./src/watchman_watcher');
 
 function sane(dir, options) {
-  if (options.poll) {
+  if (options.watcher) {
+    if (typeof(options.watcher) === 'string') {
+      var WatcherClass = require(options.watcher);
+      return new WatcherClass(dir, options);
+    } else {
+      return options.watcher;
+    }
+  } else if (options.poll) {
     return new PollWatcher(dir, options);
   } else if (options.watchman) {
     return new WatchmanWatcher(dir, options);

--- a/index.js
+++ b/index.js
@@ -6,12 +6,8 @@ var WatchmanWatcher = require('./src/watchman_watcher');
 
 function sane(dir, options) {
   if (options.watcher) {
-    if (typeof(options.watcher) === 'string') {
-      var WatcherClass = require(options.watcher);
-      return new WatcherClass(dir, options);
-    } else {
-      return options.watcher;
-    }
+    var WatcherClass = require(options.watcher);
+    return new WatcherClass(dir, options);
   } else if (options.poll) {
     return new PollWatcher(dir, options);
   } else if (options.watchman) {

--- a/test/plugin_watcher.js
+++ b/test/plugin_watcher.js
@@ -1,0 +1,124 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var watch = require('watch');
+var common = require('../src/common');
+var EventEmitter = require('events').EventEmitter;
+
+/**
+ * Constants
+ */
+
+var DEFAULT_DELAY = common.DEFAULT_DELAY;
+var CHANGE_EVENT = common.CHANGE_EVENT;
+var DELETE_EVENT = common.DELETE_EVENT;
+var ADD_EVENT = common.ADD_EVENT;
+var ALL_EVENT = common.ALL_EVENT;
+
+/**
+ * Export `PluginTestWatcher` class.
+ *
+ * This class is based on the PollWatcher but emits a special event to signal that it
+ * is the watcher that is used to verify that the plugin system is working
+ *
+ */
+
+module.exports = PluginTestWatcher;
+
+/**
+ * Watches `dir`.
+ *
+ * @class PluginTestWatcher
+ * @param String dir
+ * @param {Object} opts
+ * @public
+ */
+
+function PluginTestWatcher(dir, opts) {
+  opts = common.assignOptions(this, opts);
+
+  this.watched = Object.create(null);
+  this.root = path.resolve(dir);
+
+  watch.createMonitor(
+    this.root,
+    { interval: opts.interval || DEFAULT_DELAY,
+      filter: this.filter.bind(this)
+    },
+    this.init.bind(this)
+  );
+}
+
+PluginTestWatcher.prototype.__proto__ = EventEmitter.prototype;
+
+/**
+ * Given a fullpath of a file or directory check if we need to watch it.
+ *
+ * @param {string} filepath
+ * @param {object} stat
+ * @private
+ */
+
+PluginTestWatcher.prototype.filter = function(filepath, stat) {
+  return stat.isDirectory() || common.isFileIncluded(
+    this.globs,
+    this.dot,
+    path.relative(this.root, filepath)
+  );
+};
+
+/**
+ * Initiate the polling file watcher with the event emitter passed from
+ * `watch.watchTree`.
+ *
+ * @param {EventEmitter} monitor
+ * @public
+ */
+
+PluginTestWatcher.prototype.init = function(monitor) {
+  this.watched = monitor.files;
+  monitor.on('changed', this.emitEvent.bind(this, CHANGE_EVENT));
+  monitor.on('removed', this.emitEvent.bind(this, DELETE_EVENT));
+  monitor.on('created', this.emitEvent.bind(this, ADD_EVENT));
+  // 1 second wait because mtime is second-based.
+  setTimeout(this.emit.bind(this, 'ready'), 1000);
+
+  // This event is fired to note that this watcher is the one from the plugin system
+  setTimeout(this.emit.bind(this, 'is-test-plugin'), 1);
+};
+
+/**
+ * Transform and emit an event comming from the poller.
+ *
+ * @param {EventEmitter} monitor
+ * @public
+ */
+
+PluginTestWatcher.prototype.emitEvent = function(type, file, stat) {
+  file = path.relative(this.root, file);
+
+  if (type === DELETE_EVENT) {
+    // Matching the non-polling API
+    stat = null;
+  }
+
+  this.emit(type, file, this.root, stat);
+  this.emit(ALL_EVENT, type, file, this.root, stat);
+};
+
+/**
+ * End watching.
+ *
+ * @public
+ */
+
+PluginTestWatcher.prototype.close = function(callback) {
+  Object.keys(this.watched).forEach(function(filepath) {
+    fs.unwatchFile(filepath);
+  });
+  this.removeAllListeners();
+  if (typeof callback === 'function') {
+    setImmediate(callback.bind(null, null, true));
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,27 @@ function harness(mode) {
     }
   });
 
+  describe('sane plugin', function () {
+    beforeEach(function () {
+      this.watcher = sane(testdir, {
+        glob: '**/file_1',
+        watcher: './test/plugin_watcher',
+      });
+    });
+
+    afterEach(function (done) {
+      this.watcher.close(done);
+    });
+
+    it('uses the custom plugin watcher', function (done) {
+      this.watcher.on('is-test-plugin', function () {
+        done();
+      });
+    });
+
+  });
+
+
   describe('sane(file)', function() {
     beforeEach(function () {
       var Watcher = getWatcherClass(mode);


### PR DESCRIPTION
See https://github.com/amasad/sane/issues/54

Plugin can be specified by either an instance of a Watcher class, or,
more commonly, by a string name that will be `require`d and instantiated.

An example of a plugin that works with this is:
https://github.com/exponentjs/sane-chokidar

Feedback welcome!