### PR TITLE
make sure directory is registered before adding

### DIFF
--- a/src/node_watcher.js
+++ b/src/node_watcher.js
@@ -275,9 +275,11 @@ NodeWatcher.prototype.processChange = function(dir, event, file) {
       this.emit('error', error);
     } else if (!error && stat.isDirectory()) {
       // win32 emits usless change events on dirs.
-      if (event !== 'change' && registered) {
+      if (event !== 'change') {
         this.watchdir(fullPath);
-        this.emitEvent(ADD_EVENT, relativePath, stat);
+        if (common.isFileIncluded(this.globs, this.dot, relativePath)) {
+          this.emitEvent(ADD_EVENT, relativePath, stat);
+        }
       }
     } else {
       if (error && error.code === 'ENOENT') {

--- a/src/node_watcher.js
+++ b/src/node_watcher.js
@@ -270,16 +270,16 @@ NodeWatcher.prototype.processChange = function(dir, event, file) {
   var fullPath = path.join(dir, file);
   var relativePath = path.join(path.relative(this.root, dir), file);
   fs.lstat(fullPath, function(error, stat) {
+    var registered = this.registered(fullPath);
     if (error && error.code !== 'ENOENT') {
       this.emit('error', error);
     } else if (!error && stat.isDirectory()) {
       // win32 emits usless change events on dirs.
-      if (event !== 'change') {
+      if (event !== 'change' && registered) {
         this.watchdir(fullPath);
         this.emitEvent(ADD_EVENT, relativePath, stat);
       }
     } else {
-      var registered = this.registered(fullPath);
       if (error && error.code === 'ENOENT') {
         this.unregister(fullPath);
         this.stopWatching(fullPath);


### PR DESCRIPTION
Prevents ADD_EVENT from firing when encountering a directory not matched by glob patterns.