### PR TITLE
add API-Doc to doclets.io

### DIFF
--- a/.doclets.yml
+++ b/.doclets.yml
@@ -1,0 +1,3 @@
+dir: src
+articles:
+  - Readme: README.md

--- a/src/node_watcher.js
+++ b/src/node_watcher.js
@@ -9,6 +9,7 @@ var EventEmitter = require('events').EventEmitter;
 
 /**
  * Constants
+ * @private
  */
 
 var DEFAULT_DELAY = common.DEFAULT_DELAY;
@@ -19,6 +20,7 @@ var ALL_EVENT = common.ALL_EVENT;
 
 /**
  * Export `NodeWatcher` class.
+ * @private
  */
 
 module.exports = NodeWatcher;

--- a/src/poll_watcher.js
+++ b/src/poll_watcher.js
@@ -8,6 +8,7 @@ var EventEmitter = require('events').EventEmitter;
 
 /**
  * Constants
+ * @private
  */
 
 var DEFAULT_DELAY = common.DEFAULT_DELAY;
@@ -18,6 +19,7 @@ var ALL_EVENT = common.ALL_EVENT;
 
 /**
  * Export `PollWatcher` class.
+ * @private
  */
 
 module.exports = PollWatcher;

--- a/src/watchman_watcher.js
+++ b/src/watchman_watcher.js
@@ -9,6 +9,7 @@ var EventEmitter = require('events').EventEmitter;
 
 /**
  * Constants
+ * @private
  */
 
 var CHANGE_EVENT = common.CHANGE_EVENT;
@@ -19,6 +20,7 @@ var SUB_NAME = 'sane-sub';
 
 /**
  * Export `WatchmanWatcher` class.
+ * @private
  */
 
 module.exports = WatchmanWatcher;
@@ -27,7 +29,7 @@ module.exports = WatchmanWatcher;
 /**
  * Watches `dir`.
  *
- * @class PollWatcher
+ * @class WatchmanWatcher
  * @param String dir
  * @param {Object} opts
  * @public


### PR DESCRIPTION
Adds documentation to [doclets.io](https://doclets.io) service. Future tags and master branch will be published automatically.

[Preview generated with my account](https://doclets.io/lipp/sane/add-to-doclets)

@amasad  If you like this, you are very welcomed to login to https://doclets.io with GitHub OAuth. If you don't like it, I'd be happy to hear what you don't like about it :)

Steps required (3min):
1) @amasad  logs in to doclets.io
2) @amasad  adds sane
3) someone merges this PR