### PR TITLE
Handle advanced watchman events without `files`

### DIFF
--- a/src/watchman_watcher.js
+++ b/src/watchman_watcher.js
@@ -184,7 +184,9 @@ WatchmanWatcher.prototype.init = function() {
 
 WatchmanWatcher.prototype.handleChangeEvent = function(resp) {
   assert.equal(resp.subscription, SUB_NAME, 'Invalid subscription event.');
-  resp.files.forEach(this.handleFileChange, this);
+  if (Array.isArray(resp.files)) {
+    resp.files.forEach(this.handleFileChange, this);
+  }
 };
 
 /**


### PR DESCRIPTION
Per the [watchman documentation](https://facebook.github.io/watchman/docs/cmd/subscribe.html#advanced-settling), advanced subscription events may be fired that do not have the `files` property. Currently this causes `WatchmanWatcher` to fatal. This fixes `WatchmanWatcher` to not fatal.