### PR TITLE
Add unit test for multi-level subdirectory creation

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -139,6 +139,36 @@ function harness(mode) {
       });
     });
 
+    it('emits events for subdir/subdir files', function(done) {
+      var subdir1 = 'subsub_1';
+      var subdir2 = 'subsub_2';
+      var filename = 'file_1';
+      var testfile = jo(testdir, subdir1, subdir2, filename);
+      var addedSubdir1 = false;
+      var addedSubdir2 = false;
+      var addedFile = false;
+      this.watcher.on('add', function(filepath, dir) {
+        if (filepath === subdir1) {
+          assert.equal(addedSubdir1, false);
+          addedSubdir1 = true;
+        } else if (filepath === jo(subdir1, subdir2)) {
+          assert.equal(addedSubdir2, false);
+          addedSubdir2 = true;
+        } else if (filepath === jo(subdir1, subdir2, filename)) {
+          assert.equal(addedFile, false);
+          addedFile = true;
+        }
+        if (addedSubdir1 && addedSubdir2 && addedFile) {
+          done();
+        }
+      });
+      this.watcher.on('ready', function() {
+        fs.mkdirSync(jo(testdir, subdir1))
+        fs.mkdirSync(jo(testdir, subdir1, subdir2))
+        fs.writeFileSync(testfile, 'wow');
+      });
+    });
+
     it('adding a file will trigger an add event', function(done) {
       var testfile = jo(testdir, 'file_x' + Math.floor(Math.random() * 10000));
       this.watcher.on('add', function(filepath, dir, stat) {


### PR DESCRIPTION
This problem occurs when you use `mkdir -p`, or make two folders at once. Nothing below the second level is watched properly with polling or "normal" mode.

It works as expected when using watchman.

I don't have a fix for this bug, but I was hoping this unit test makes it easier for someone else to create a fix!
