### PR TITLE
Add `ignored` option.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "amasad",
   "license": "MIT",
   "dependencies": {
+    "anymatch": "^1.3.0",
     "exec-sh": "^0.2.0",
     "fb-watchman": "^1.8.0",
     "minimatch": "^3.0.2",

--- a/src/common.js
+++ b/src/common.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var anymatch = require('anymatch');
 var minimatch = require('minimatch');
 
 /**
@@ -28,6 +29,9 @@ exports.assignOptions = function(watcher, opts) {
   if (!Array.isArray(watcher.globs)) {
     watcher.globs = [watcher.globs];
   }
+  watcher.doIgnore = opts.ignored ? anymatch(opts.ignored) : function () {
+    return false;
+  };
   return opts;
 };
 
@@ -40,22 +44,20 @@ exports.assignOptions = function(watcher, opts) {
  * @public
  */
 
-exports.isFileIncluded = function(globs, dot, relativePath) {
+exports.isFileIncluded = function(globs, dot, doIgnore, relativePath) {
   var matched;
   if (globs.length) {
     for (var i = 0; i < globs.length; i++) {
-      if (minimatch(relativePath, globs[i], {dot: dot})) {
+      if (minimatch(relativePath, globs[i], {dot: dot}) &&
+        !doIgnore(relativePath)) {
         matched = true;
         break;
       }
     }
   } else {
     // Make sure we honor the dot option if even we're not using globs.
-    if (!dot) {
-      matched = minimatch(relativePath, '**/*', {dot: false});
-    } else {
-      matched = true;
-    }
+    matched = (dot || minimatch(relativePath, '**/*')) &&
+      !doIgnore(relativePath);
   }
   return matched;
 };

--- a/src/node_watcher.js
+++ b/src/node_watcher.js
@@ -72,7 +72,11 @@ NodeWatcher.prototype.__proto__ = EventEmitter.prototype;
 
 NodeWatcher.prototype.register = function(filepath) {
   var relativePath = path.relative(this.root, filepath);
-  if (!common.isFileIncluded(this.globs, this.dot, relativePath)) {
+  if (!common.isFileIncluded(
+    this.globs,
+    this.dot,
+    this.doIgnore,
+    relativePath)) {
     return false;
   }
 
@@ -276,7 +280,11 @@ NodeWatcher.prototype.processChange = function(dir, event, file) {
       // win32 emits usless change events on dirs.
       if (event !== 'change') {
         this.watchdir(fullPath);
-        if (common.isFileIncluded(this.globs, this.dot, relativePath)) {
+        if (common.isFileIncluded(
+          this.globs,
+          this.dot,
+          this.doIgnore,
+          relativePath)) {
           this.emitEvent(ADD_EVENT, relativePath, stat);
         }
       }

--- a/src/poll_watcher.js
+++ b/src/poll_watcher.js
@@ -60,6 +60,7 @@ PollWatcher.prototype.filter = function(filepath, stat) {
   return stat.isDirectory() || common.isFileIncluded(
     this.globs,
     this.dot,
+    this.doIgnore,
     path.relative(this.root, filepath)
   );
 };

--- a/src/watchman_watcher.js
+++ b/src/watchman_watcher.js
@@ -215,7 +215,11 @@ WatchmanWatcher.prototype.handleFileChange = function(changeDescriptor) {
   }
 
   if (!self.capabilities.wildmatch &&
-      !common.isFileIncluded(this.globs, this.dot, relativePath)) {
+      !common.isFileIncluded(
+        this.globs,
+        this.dot,
+        this.doIgnore,
+        relativePath)) {
     return;
   }
 

--- a/test/plugin_watcher.js
+++ b/test/plugin_watcher.js
@@ -64,6 +64,7 @@ PluginTestWatcher.prototype.filter = function(filepath, stat) {
   return stat.isDirectory() || common.isFileIncluded(
     this.globs,
     this.dot,
+    this.doIgnore,
     path.relative(this.root, filepath)
   );
 };

--- a/test/test.js
+++ b/test/test.js
@@ -418,6 +418,37 @@ function harness(mode) {
     });
   });
 
+  describe('sane(dir, ignored)', function() {
+    beforeEach(function () {
+      var Watcher = getWatcherClass(mode);
+      this.watcher = new Watcher(
+        testdir,
+        { ignored: ['**/file_3', /file_4/, function (file) {
+            return file.indexOf('file_5') !== -1;
+          }] });
+    });
+
+    afterEach(function(done) {
+      this.watcher.close(done);
+    });
+
+    it('ignores files', function (done) {
+      var i = 0;
+      this.watcher.on('change', function(filepath, dir) {
+        assert.ok(filepath.match(/file_(1|2)/), 'only file_1 and file_2');
+        assert.equal(dir, testdir);
+        if (++i == 2) done();
+      });
+      this.watcher.on('ready', function() {
+        fs.writeFileSync(jo(testdir, 'file_1'), 'wow');
+        fs.writeFileSync(jo(testdir, 'file_4'), 'wow');
+        fs.writeFileSync(jo(testdir, 'file_3'), 'wow');
+        fs.writeFileSync(jo(testdir, 'file_5'), 'wow');
+        fs.writeFileSync(jo(testdir, 'file_2'), 'wow');
+      });
+    });
+  });
+
   describe('sane shortcut alias', function () {
     beforeEach(function () {
       this.watcher = sane(testdir, {


### PR DESCRIPTION
Allows `sane` to take an `ignored` option.
```
sane(dir, { ignored: /node_modules/ });
```
`ignored` can take a glob, a regex, a function, or an array of any combination of those.  It's useful for systems moving from `chokidar` to `sane`.