### PR TITLE
Switch from `minimatch` to `micromatch`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "anymatch": "^1.3.0",
     "exec-sh": "^0.2.0",
     "fb-watchman": "^1.8.0",
-    "minimatch": "^3.0.2",
+    "micromatch": "^2.3.11",
     "minimist": "^1.1.1",
     "walker": "~1.0.5",
     "watch": "~0.10.0"

--- a/src/common.js
+++ b/src/common.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var anymatch = require('anymatch');
-var minimatch = require('minimatch');
+var micromatch = require('micromatch');
 
 /**
  * Constants
@@ -50,7 +50,7 @@ exports.isFileIncluded = function(globs, dot, doIgnore, relativePath) {
   var matched;
   if (globs.length) {
     for (var i = 0; i < globs.length; i++) {
-      if (minimatch(relativePath, globs[i], {dot: dot}) &&
+      if (micromatch.isMatch(relativePath, globs[i], {dot: dot}) &&
         !doIgnore(relativePath)) {
         matched = true;
         break;
@@ -58,7 +58,7 @@ exports.isFileIncluded = function(globs, dot, doIgnore, relativePath) {
     }
   } else {
     // Make sure we honor the dot option if even we're not using globs.
-    matched = (dot || minimatch(relativePath, '**/*')) &&
+    matched = (dot || micromatch.isMatch(relativePath, '**/*')) &&
       !doIgnore(relativePath);
   }
   return matched;


### PR DESCRIPTION
Reduces dependencies, since `anymatch` already uses `micromatch`.  And it's [supposedly faster](https://github.com/jonschlinkert/micromatch#benchmarks).