### PR TITLE
Prevent change on add in node watcher

### DIFF
--- a/src/node_watcher.js
+++ b/src/node_watcher.js
@@ -317,6 +317,11 @@ NodeWatcher.prototype.processChange = function(dir, event, file) {
 
 NodeWatcher.prototype.emitEvent = function(type, file, stat) {
   var key = type + '-' + file;
+  var addKey = ADD_EVENT + '-' + file;
+  if (type === CHANGE_EVENT && this.changeTimers[addKey]) {
+    type = ADD_EVENT;
+    key = addKey;
+  }
   clearTimeout(this.changeTimers[key]);
   this.changeTimers[key] = setTimeout(function() {
     delete this.changeTimers[key];

--- a/src/node_watcher.js
+++ b/src/node_watcher.js
@@ -319,8 +319,9 @@ NodeWatcher.prototype.emitEvent = function(type, file, stat) {
   var key = type + '-' + file;
   var addKey = ADD_EVENT + '-' + file;
   if (type === CHANGE_EVENT && this.changeTimers[addKey]) {
-    type = ADD_EVENT;
-    key = addKey;
+    // Ignore the change event that is immediately fired after an add event.
+    // (This happens on Linux).
+    return;
   }
   clearTimeout(this.changeTimers[key]);
   this.changeTimers[key] = setTimeout(function() {

--- a/test/test.js
+++ b/test/test.js
@@ -181,6 +181,9 @@ function harness(mode) {
         assert.equal(dir, testdir);
         done();
       });
+      this.watcher.on('change', function(filepath, dir, stat) {
+        done(new Error('Should not emit change on add'))
+      })
       this.watcher.on('ready', function() {
         fs.writeFileSync(testfile, 'wow');
       });


### PR DESCRIPTION
Turns change events into add events if the add event hasn't yet been emitted. Fixes #75.