### PR TITLE
Modified ignored filter for node_watcher to avoid common exception

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -26,6 +26,8 @@ exports.assignOptions = function(watcher, opts) {
   opts = opts || {};
   watcher.globs = opts.glob || [];
   watcher.dot = opts.dot || false;
+  watcher.ignored = opts.ignored || false;
+
   if (!Array.isArray(watcher.globs)) {
     watcher.globs = [watcher.globs];
   }


### PR DESCRIPTION
@amasad 
This PR updates `node_watcher` to pass the ignore filters to [nodejs_walker](https://github.com/daaku/nodejs-walker) so that they can be ignored immediately by nodejs_walker rather than later on in the process.

This was done because on macOS Sierra something (probably `fs.lstat`) appears to crash when it is searching too many files/directories.

This change will allow a fix in [Jest](https://github.com/facebook/jest/) to solve issue facebook/jest#1767, which should also fix [Create-React-App](https://github.com/facebookincubator/) issue facebookincubator/create-react-app#871 and possibly [React Native](https://github.com/facebook/react-native/issues/10028) issue facebook/react-native#10028.

I have added a new test, to make sure subdirs are being ignored.

*Edit: Updated original commit to improve tests and removed old comments*

This may also solve issue #72