### PR TITLE
Bump `fb-watchman`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "exec-sh": "^0.2.0",
-    "fb-watchman": "^1.8.0",
+    "fb-watchman": "^2.0.0",
     "minimatch": "^3.0.2",
     "minimist": "^1.1.1",
     "walker": "~1.0.5",


### PR DESCRIPTION
Bumps `fb-watchman`.  This was preventing deduplication with `jest`.
The major bump was for replacing [`console.log` with `console.error`](https://github.com/facebook/watchman/commit/ee0e85b2b891b58a3b88d6b4a0ba7e1d6d5fd6b9) and a BSER fix.