### PR TITLE
FSEvents watcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var NodeWatcher = require('./src/node_watcher');
 var PollWatcher = require('./src/poll_watcher');
 var WatchmanWatcher = require('./src/watchman_watcher');
+var FSEventsWatcher = require('./src/fsevents_watcher');
 
 function sane(dir, options) {
   options = options || {};
@@ -13,6 +14,8 @@ function sane(dir, options) {
     return new PollWatcher(dir, options);
   } else if (options.watchman) {
     return new WatchmanWatcher(dir, options);
+  } else if (options.fsevents) {
+    return new FSEventsWatcher(dir, options);
   } else {
     return new NodeWatcher(dir, options);
   }
@@ -22,3 +25,4 @@ module.exports = sane;
 sane.NodeWatcher = NodeWatcher;
 sane.PollWatcher = PollWatcher;
 sane.WatchmanWatcher = WatchmanWatcher;
+sane.FSEventsWatcher = FSEventsWatcher;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "index.js"
   ],
   "scripts": {
-    "prepublish": "jshint --config=.jshintrc src/ index.js && mocha --bail",
+    "prepublish": "npm run test",
     "test": "npm run format && eslint src/ test/ index.js && mocha --bail test/test.js && mocha --bail test/utils-test.js",
     "test:debug": "mocha debug --bail",
     "format": "prettier --trailing-comma es5 --single-quote --write index.js 'src/**/*.js' 'test/**/*.js'"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "index.js"
   ],
   "scripts": {
-    "prepublish": "npm run test",
     "test": "npm run format && eslint src/ test/ index.js && mocha --bail test/test.js && mocha --bail test/utils-test.js",
     "test:debug": "mocha debug --bail",
     "format": "prettier --trailing-comma es5 --single-quote --write index.js 'src/**/*.js' 'test/**/*.js'"

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
   "bugs": {
     "url": "https://github.com/amasad/sane/issues"
   },
-  "homepage": "https://github.com/amasad/sane"
+  "homepage": "https://github.com/amasad/sane",
+  "optionalDependencies": {
+    "fsevents": "^1.1.1"
+  }
 }

--- a/src/fsevents_watcher.js
+++ b/src/fsevents_watcher.js
@@ -97,7 +97,7 @@ FSEventsWatcher.prototype.close = function(callback) {
   this.watcher.stop();
   this.removeAllListeners();
   if (typeof callback === 'function') {
-    setImmediate(callback.bind(null, null, true));
+    process.nextTick(callback.bind(null, null, true));
   }
 };
 

--- a/src/fsevents_watcher.js
+++ b/src/fsevents_watcher.js
@@ -38,9 +38,11 @@ function FSEventsWatcher(dir, opts) {
 
   this.watcher
     .start()
+    .on('modified', this.emitEvent.bind(this, CHANGE_EVENT))
     .on('created', this.emitEvent.bind(this, ADD_EVENT))
-    .on('deleted', this.emitEvent.bind(this, DELETE_EVENT))
-    .on('modified', this.emitEvent.bind(this, CHANGE_EVENT));
+    .on('deleted', this.emitEvent.bind(this, DELETE_EVENT));
+
+  setTimeout(this.emit.bind(this, 'ready'));
 }
 
 FSEventsWatcher.prototype.__proto__ = EventEmitter.prototype;
@@ -89,9 +91,9 @@ FSEventsWatcher.prototype.emitEvent = function(type, file) {
   }
 
   function emit(stat) {
-    file = path.relative(this.root, file);
-    this.emit(type, file, this.root, stat);
-    this.emit(ALL_EVENT, type, file, this.root, stat);
+    file = path.relative(self.root, file);
+    self.emit(type, file, self.root, stat);
+    self.emit(ALL_EVENT, type, file, self.root, stat);
   }
 };
 

--- a/src/fsevents_watcher.js
+++ b/src/fsevents_watcher.js
@@ -1,0 +1,110 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var common = require('./common');
+var EventEmitter = require('events').EventEmitter;
+var fsevents = require('fsevents');
+
+/**
+ * Constants
+ */
+
+var CHANGE_EVENT = common.CHANGE_EVENT;
+var DELETE_EVENT = common.DELETE_EVENT;
+var ADD_EVENT = common.ADD_EVENT;
+var ALL_EVENT = common.ALL_EVENT;
+
+/**
+ * Export `FSEventsWatcher` class.
+ */
+
+module.exports = FSEventsWatcher;
+
+/**
+ * Watches `dir`.
+ *
+ * @class FSEventsWatcher
+ * @param String dir
+ * @param {Object} opts
+ * @public
+ */
+
+function FSEventsWatcher(dir, opts) {
+  common.assignOptions(this, opts);
+
+  this.root = path.resolve(dir);
+  this.watcher = fsevents(this.root);
+
+  this.watcher
+    .start()
+    .on('created', this.emitEvent.bind(this, ADD_EVENT))
+    .on('deleted', this.emitEvent.bind(this, DELETE_EVENT))
+    .on('modified', this.emitEvent.bind(this, CHANGE_EVENT));
+}
+
+FSEventsWatcher.prototype.__proto__ = EventEmitter.prototype;
+
+/**
+ * Given an absolute path of a file or directory check if we need to watch it.
+ *
+ * @param {string} filepath
+ * @param {object} stat
+ * @private
+ */
+
+FSEventsWatcher.prototype.filter = function(filepath, stat) {
+  return (
+    stat.isDirectory() ||
+    common.isFileIncluded(
+      this.globs,
+      this.dot,
+      this.doIgnore,
+      path.relative(this.root, filepath)
+    )
+  );
+};
+
+/**
+ * Normalize and emit an event.
+ *
+ * @param {EventEmitter} monitor
+ * @private
+ */
+
+FSEventsWatcher.prototype.emitEvent = function(type, file) {
+  var self = this;
+  console.log('here');
+  if (type === DELETE_EVENT) {
+    emit(null);
+  } else {
+    fs.lstat(file, function(err, stat) {
+      if (err) {
+        self.emit('error', err);
+        return;
+      }
+
+      emit(stat);
+    });
+  }
+
+  function emit(stat) {
+    file = path.relative(this.root, file);
+    this.emit(type, file, this.root, stat);
+    this.emit(ALL_EVENT, type, file, this.root, stat);
+  }
+};
+
+/**
+ * End watching.
+ *
+ * @public
+ */
+
+FSEventsWatcher.prototype.close = function(callback) {
+  this.watcher.stop();
+  this.removeAllListeners();
+  if (typeof callback === 'function') {
+    setImmediate(callback.bind(null, null, true));
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,8 @@ function getWatcherClass(mode) {
     return sane.WatchmanWatcher;
   } else if (mode.poll) {
     return sane.PollWatcher;
+  } else if (mode.fsevents) {
+    return sane.FSEventsWatcher;
   } else {
     return sane.NodeWatcher;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,7 @@ describe('sane in polling mode', function() {
 describe('sane in node mode', function() {
   harness.call(this, {});
 });
-describe.only('sane in fsevents mode', function() {
+describe('sane in fsevents mode', function() {
   harness.call(this, { fsevents: true });
 });
 describe('sane in watchman mode', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -14,8 +14,11 @@ var jo = path.join.bind(path);
 describe('sane in polling mode', function() {
   harness.call(this, { poll: true });
 });
-describe('sane in normal mode', function() {
+describe('sane in node mode', function() {
   harness.call(this, {});
+});
+describe.only('sane in fsevents mode', function() {
+  harness.call(this, { fsevents: true });
 });
 describe('sane in watchman mode', function() {
   harness.call(this, { watchman: true });

--- a/test/test.js
+++ b/test/test.js
@@ -150,70 +150,6 @@ function harness(mode) {
         fs.writeFileSync(testfile, 'wow');
       });
     });
-
-    if (!mode.poll) {
-      it('emits events for subdir/subdir files', function(done) {
-        var subdir1 = 'subsub_1';
-        var subdir2 = 'subsub_2';
-        var filename = 'file_1';
-        var testfile = jo(testdir, subdir1, subdir2, filename);
-        var addedSubdir1 = false;
-        var addedSubdir2 = false;
-        var addedFile = false;
-        this.watcher.on('add', function(filepath) {
-          if (filepath === subdir1) {
-            assert.equal(addedSubdir1, false);
-            addedSubdir1 = true;
-          } else if (filepath === jo(subdir1, subdir2)) {
-            assert.equal(addedSubdir2, false);
-            addedSubdir2 = true;
-          } else if (filepath === jo(subdir1, subdir2, filename)) {
-            assert.equal(addedFile, false);
-            addedFile = true;
-          }
-          if (addedSubdir1 && addedSubdir2 && addedFile) {
-            done();
-          }
-        });
-        this.watcher.on('ready', function() {
-          fs.mkdirSync(jo(testdir, subdir1));
-          fs.mkdirSync(jo(testdir, subdir1, subdir2));
-          fs.writeFileSync(testfile, 'wow');
-        });
-      });
-      it('emits events for subdir/subdir files 2', function(done) {
-        var subdir1 = 'subsub_1b';
-        var subdir2 = 'subsub_2b';
-        var filename = 'file_1b';
-        var testfile = jo(testdir, subdir1, subdir2, filename);
-        var addedSubdir1 = false;
-        var addedSubdir2 = false;
-        var addedFile = false;
-        this.watcher.on('add', function(filepath) {
-          if (filepath === subdir1) {
-            assert.equal(addedSubdir1, false);
-            addedSubdir1 = true;
-          } else if (filepath === jo(subdir1, subdir2)) {
-            assert.equal(addedSubdir2, false);
-            addedSubdir2 = true;
-          } else if (filepath === jo(subdir1, subdir2, filename)) {
-            assert.equal(addedFile, false);
-            addedFile = true;
-          }
-          if (addedSubdir1 && addedSubdir2 && addedFile) {
-            done();
-          }
-        });
-        this.watcher.on('ready', function() {
-          fs.mkdirSync(jo(testdir, subdir1));
-          fs.mkdirSync(jo(testdir, subdir1, subdir2));
-          setTimeout(function() {
-            fs.writeFileSync(testfile, 'wow');
-          }, 500);
-        });
-      });
-    }
-
     it('adding a file will trigger an add event', function(done) {
       var testfile = jo(testdir, 'file_x' + Math.floor(Math.random() * 10000));
       this.watcher.on('add', function(filepath, dir, stat) {
@@ -381,6 +317,69 @@ function harness(mode) {
         });
       });
     });
+
+    if (!mode.poll) {
+      it('emits events for subdir/subdir files', function(done) {
+        var subdir1 = 'subsub_1';
+        var subdir2 = 'subsub_2';
+        var filename = 'file_1';
+        var testfile = jo(testdir, subdir1, subdir2, filename);
+        var addedSubdir1 = false;
+        var addedSubdir2 = false;
+        var addedFile = false;
+        this.watcher.on('add', function(filepath) {
+          if (filepath === subdir1) {
+            assert.equal(addedSubdir1, false);
+            addedSubdir1 = true;
+          } else if (filepath === jo(subdir1, subdir2)) {
+            assert.equal(addedSubdir2, false);
+            addedSubdir2 = true;
+          } else if (filepath === jo(subdir1, subdir2, filename)) {
+            assert.equal(addedFile, false);
+            addedFile = true;
+          }
+          if (addedSubdir1 && addedSubdir2 && addedFile) {
+            done();
+          }
+        });
+        this.watcher.on('ready', function() {
+          fs.mkdirSync(jo(testdir, subdir1));
+          fs.mkdirSync(jo(testdir, subdir1, subdir2));
+          fs.writeFileSync(testfile, 'wow');
+        });
+      });
+      it('emits events for subdir/subdir files 2', function(done) {
+        var subdir1 = 'subsub_1b';
+        var subdir2 = 'subsub_2b';
+        var filename = 'file_1b';
+        var testfile = jo(testdir, subdir1, subdir2, filename);
+        var addedSubdir1 = false;
+        var addedSubdir2 = false;
+        var addedFile = false;
+        this.watcher.on('add', function(filepath) {
+          if (filepath === subdir1) {
+            assert.equal(addedSubdir1, false);
+            addedSubdir1 = true;
+          } else if (filepath === jo(subdir1, subdir2)) {
+            assert.equal(addedSubdir2, false);
+            addedSubdir2 = true;
+          } else if (filepath === jo(subdir1, subdir2, filename)) {
+            assert.equal(addedFile, false);
+            addedFile = true;
+          }
+          if (addedSubdir1 && addedSubdir2 && addedFile) {
+            done();
+          }
+        });
+        this.watcher.on('ready', function() {
+          fs.mkdirSync(jo(testdir, subdir1));
+          fs.mkdirSync(jo(testdir, subdir1, subdir2));
+          setTimeout(function() {
+            fs.writeFileSync(testfile, 'wow');
+          }, 500);
+        });
+      });
+    }
   });
 
   describe('sane(file, glob)', function() {


### PR DESCRIPTION
There seems to be some kind of regression with the node watcher in MacOS serria:
* [create-react-app issue](https://github.com/facebookincubator/create-react-app/issues/2393)
* [jest](https://github.com/facebook/jest/issues/1767)
* [react native](https://github.com/facebook/react-native/issues/10028)

This adds another watcher that consumers can use for MacOS. 