### PR TITLE
Expose ignored option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ Usage: sane <command> [...directory] [--glob=<filePattern>] [--poll] [--watchman
 
 OPTIONS:
     --glob=<filePattern>
-        A single string glob pattern or an array of them.
+      A single string glob pattern or an array of them.
+
+    --ignored=<filePattern>
+      A glob, regex, function, or array of any combination.
 
     --poll, -p
       Use polling mode.
@@ -107,9 +110,9 @@ OPTIONS:
       Enables watching files/directories that start with a dot.
 
     --wait=<seconds>
-        Duration, in seconds, that watching will be disabled
-        after running <command>. Setting this option will
-        throttle calls to <command> for the specified duration.
+      Duration, in seconds, that watching will be disabled
+      after running <command>. Setting this option will
+      throttle calls to <command> for the specified duration.
 ```
 
 It will watch the given `directory` and run the given <command> every time a file changes.
@@ -118,6 +121,7 @@ It will watch the given `directory` and run the given <command> every time a fil
 - `sane 'echo "A command ran"'`
 - `sane 'echo "A command ran"' --glob='**/*.css'`
 - `sane 'echo "A command ran"' site/assets/css --glob='**/*.css'`
+- `sane 'echo "A command ran"' --glob='**/*.css' --ignored='**/ignore.css'`
 - `sane 'echo "A command ran"' --wait=3`
 - `sane 'echo "A command ran"' -p`
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,8 @@ var execshell = require('exec-sh');
 if (argv._.length === 0) {
   var msg =
     'Usage: sane <command> [...directory] [--glob=<filePattern>] ' +
-    '[--poll] [--watchman] [--dot] [--wait=<seconds>]';
+    '[--ignored=<filePattern>] [--poll] [--watchman] [--dot] ' +
+    '[--wait=<seconds>]';
   console.error(msg);
   process.exit();
 }
@@ -19,6 +20,7 @@ var dir = argv._[1] || process.cwd();
 var waitTime = Number(argv.wait || argv.w);
 var dot = argv.dot || argv.d;
 var glob = argv.glob || argv.g;
+var ignored = argv.ignored || argv.i;
 var poll = argv.poll || argv.p;
 var watchman = argv.watchman || argv.w;
 
@@ -27,6 +29,9 @@ if (dot) {
 }
 if (glob) {
   opts.glob = glob;
+}
+if (ignored) {
+  opts.ignored = ignored;
 }
 if (poll) {
   opts.poll = true;


### PR DESCRIPTION
Seems like the ignored option was not exposed via the CLI yet. This option can especially be helpful if you would like to watch a folder, but ignore something like node_modules or example folders.