### PR TITLE
Improve error handling in node_watcher

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -89,6 +89,7 @@ exports.recReaddir = function(
   dirCallback,
   fileCallback,
   endCallback,
+  errorCallback,
   ignored
 ) {
   walker(dir)
@@ -97,6 +98,7 @@ exports.recReaddir = function(
     })
     .on('dir', normalizeProxy(dirCallback))
     .on('file', normalizeProxy(fileCallback))
+    .on('error', errorCallback)
     .on('end', function() {
       if (platform === 'win32') {
         setTimeout(endCallback, 1000);

--- a/src/fsevents_watcher.js
+++ b/src/fsevents_watcher.js
@@ -56,6 +56,7 @@ function FSEventsWatcher(dir, opts) {
     filepath => (this._tracked[filepath] = true),
     filepath => (this._tracked[filepath] = true),
     this.emit.bind(this, 'ready'),
+    this.emit.bind(this, 'error'),
     this.ignored
   );
 }


### PR DESCRIPTION
- common.recReaddir now has an error handler (previously would crash the
  node process due to no "error" event handler)
- node_watcher and fsevents_watcher re-emit recReaddir "error" events
- node_watcher now ignores EPERM errors on win32 in more cases

This should fix #89 