### PR TITLE
Bump watch version to ~0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "minimatch": "^3.0.2",
     "minimist": "^1.1.1",
     "walker": "~1.0.5",
-    "watch": "~0.10.0"
+    "watch": "~0.18.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -86,7 +86,7 @@ describe.only('RecrawlWarning', function() {
       it('new message', function() {
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 1 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 1 times, most recently because:\n/foo/bar/baz:'
           ),
           false
         );
@@ -95,13 +95,13 @@ describe.only('RecrawlWarning', function() {
       it('same message twice', function() {
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 2 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 2 times, most recently because:\n/foo/bar/baz:'
           ),
           false
         );
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 2 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 2 times, most recently because:\n/foo/bar/baz:'
           ),
           true
         );
@@ -110,13 +110,13 @@ describe.only('RecrawlWarning', function() {
       it('same count, but different root twice', function() {
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 2 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 2 times, most recently because:\n/foo/bar/baz:'
           ),
           false
         );
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 2 times, most recently because:\n\/baz\/bar\/baz:'
+            'Recrawled this watch 2 times, most recently because:\n/baz/bar/baz:'
           ),
           false
         );
@@ -125,19 +125,19 @@ describe.only('RecrawlWarning', function() {
       it('incrementing count, but fixed root', function() {
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 2 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 2 times, most recently because:\n/foo/bar/baz:'
           ),
           false
         );
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 3 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 3 times, most recently because:\n/foo/bar/baz:'
           ),
           false
         );
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 4 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 4 times, most recently because:\n/foo/bar/baz:'
           ),
           false
         );
@@ -146,19 +146,19 @@ describe.only('RecrawlWarning', function() {
       it('decrementing count, but fixed root', function() {
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 4 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 4 times, most recently because:\n/foo/bar/baz:'
           ),
           false
         );
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 3 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 3 times, most recently because:\n/foo/bar/baz:'
           ),
           true
         );
         assert.equal(
           RecrawlWarning.isRecrawlWarningDupe(
-            'Recrawled this watch 2 times, most recently because:\n\/foo\/bar\/baz:'
+            'Recrawled this watch 2 times, most recently because:\n/foo/bar/baz:'
           ),
           true
         );


### PR DESCRIPTION
https://www.sourceclear.com/registry/libraries/watch/javascript/npm/lid-7332/versions/0.10.0/vulnerabilities
> Licenses
> UNKNOWN

The `sane` currently depends on `watch@~0.10.0`. The `watch@~0.10.0` doesn't have correct a license information by SourceClear. The correct license information have added in `watch` v0.17.0 or later.
https://github.com/mikeal/watch/commit/7802a55bab6bf47567ba303de96afb35d620b095

I tried to upgrade `watch` version to the latest version v1.0.2, but `watch` v0.19.3 or later seems to have a breaking change.
https://www.npmjs.com/package/watch
https://github.com/mikeal/watch/commit/5ac469084c5edb1ab75d428b457099cef1e3d210

I think this patch resolves this issue with maintenance of back compatible for `sane`. And, the test code changes also are auto fixing by `npm test` and `prettier`.
