### PR TITLE
watchman_watcher: forward is_fresh_instance as an event

### DIFF
--- a/src/watchman_watcher.js
+++ b/src/watchman_watcher.js
@@ -193,6 +193,9 @@ WatchmanWatcher.prototype.init = function() {
 
 WatchmanWatcher.prototype.handleChangeEvent = function(resp) {
   assert.equal(resp.subscription, SUB_NAME, 'Invalid subscription event.');
+  if (resp.is_fresh_instance) {
+    this.emit('fresh_instance');
+  }
   if (Array.isArray(resp.files)) {
     resp.files.forEach(this.handleFileChange, this);
   }


### PR DESCRIPTION
As it happens, watchman can signal an `is_fresh_instance` in subscription events. This is [documented on the `query` page](https://facebook.github.io/watchman/docs/cmd/query.html), but can happen for subscription events as well according with @wez.

This changeset add a new event that forward this occurrence, as it means applications need to recrawl the filesystem. As this module is not concerned by file crawling in the first place, there's no way we can really handle this in a self-contained way: applications need to decide how to handle it, instead.

Note that exposing the `is_fresh_instance` feature as a simple event from `sane` is brittle and poor design: indeed, it is too easy to ignore an event, unknowingly keeping the application in a bad state. However, it has been the case for all that time already. Plus, simply adding a new event prevents us from having to release a major/breaking release.

The alternative strategy would be to force people to pass a handler as argument to the watcher constructor (so, to the `sane` top-level function), or to shutdown the watcher instance whenever there is a fresh instance. But this would require a major version release. So I think the best tradeoff is forwarding the flag as an event.
