### PR TITLE
Allow to set a custom Watchman binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ options:
 * `glob`: a single string glob pattern or an array of them.
 * `poll`: puts the watcher in polling mode. Under the hood that means `fs.watchFile`.
 * `watchman`: makes the watcher use [watchman](https://facebook.github.io/watchman/).
+* `watchmanPath`: sets a custom path for `watchman` binary.
 * `dot`: enables watching files/directories that start with a dot.
 * `ignored`: a glob, regex, function, or array of any combination.
 
@@ -91,7 +92,7 @@ All events are passed the file/dir path relative to the root directory
 This module includes a simple command line interface, which you can install with `npm install sane -g`.
 
 ```
-Usage: sane <command> [...directory] [--glob=<filePattern>] [--poll] [--watchman] [--dot] [--wait=<seconds>]
+Usage: sane <command> [...directory] [--glob=<filePattern>] [--poll] [--watchman] [--watchman-path=<watchmanBinaryPath>] [--dot] [--wait=<seconds>]
 
 OPTIONS:
     --glob=<filePattern>
@@ -105,6 +106,9 @@ OPTIONS:
 
     --watchman, -w
       Use watchman (if available).
+
+    --watchman-path=<watchmanBinaryPath>
+      Sets a custom path for watchman binary (if using this mode).
 
     --dot, -d
       Enables watching files/directories that start with a dot.

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,7 @@ var execshell = require('exec-sh');
 if (argv._.length === 0) {
   var msg =
     'Usage: sane <command> [...directory] [--glob=<filePattern>] ' +
-    '[--ignored=<filePattern>] [--poll] [--watchman] [--dot] ' +
+    '[--ignored=<filePattern>] [--poll] [--watchman] [--watchman-path=<watchmanBinaryPath>] [--dot] ' +
     '[--wait=<seconds>]';
   console.error(msg);
   process.exit();
@@ -23,6 +23,7 @@ var glob = argv.glob || argv.g;
 var ignored = argv.ignored || argv.i;
 var poll = argv.poll || argv.p;
 var watchman = argv.watchman || argv.w;
+var watchmanPath = argv['watchman-path'];
 
 if (dot) {
   opts.dot = true;
@@ -38,6 +39,9 @@ if (poll) {
 }
 if (watchman) {
   opts.watchman = true;
+}
+if (watchmanPath) {
+  opts.watchmanPath = watchmanPath;
 }
 
 var wait = false;

--- a/src/common.js
+++ b/src/common.js
@@ -41,6 +41,11 @@ exports.assignOptions = function(watcher, opts) {
     : function() {
         return false;
       };
+
+  if (opts.watchman && opts.watchmanPath) {
+    watcher.watchmanPath = opts.watchmanPath;
+  }
+
   return opts;
 };
 

--- a/src/watchman_watcher.js
+++ b/src/watchman_watcher.js
@@ -53,7 +53,9 @@ WatchmanWatcher.prototype.init = function() {
   }
 
   var self = this;
-  this.client = new watchman.Client();
+  this.client = new watchman.Client(
+    this.watchmanPath ? { watchmanBinaryPath: this.watchmanPath } : {}
+  );
   this.client.on('error', function(error) {
     self.emit('error', error);
   });


### PR DESCRIPTION
Hi there,

We are planning to use `sane` with `watchman` mode in a distributed app. We'll directly embed the `watchman` binary in the app, thus it won't be installed in the `PATH` of the clients. 

The `fb-watchman` library allows to specify the `watchmanBinaryPath` in the `Client` constructor. This simple PR is here to allow to set this option with `sane` ; I think it could be useful for many devs out there without polluting the code base too much.

Best regards,

François