### PR TITLE
Updated to WatchmanWatcher, created singleton WatchmanClient using promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ maintains the same API across all modes and will be easy to switch.
 
 ### sane(dir, options)
 
-Watches a directory and all it's descendant directories for changes, deletions, and additions on files and directories.
+Watches a directory and all its descendant directories for changes, deletions, and additions on files and directories.
 
 ```js
 var watcher = sane('path/to/dir', {glob: ['**/*.js', '**/*.css']});

--- a/src/watchman_client.js
+++ b/src/watchman_client.js
@@ -1,0 +1,314 @@
+'use strict';
+
+var watchman = require('fb-watchman');
+
+/**
+ * Constants
+ */
+
+/**
+ * Singleton that provides a public API for a single connection to a watchman instance for 'sane'.
+ * It tries to abstract/remove as much of the boilerplate processing as necessary
+ * from WatchmanWatchers that use it. In particular, they have no idea whether
+ * we're using 'watch-project' or 'watch', what the 'project root' is when
+ * we internally use watch-project, whether a connection has been lost
+ * and reestablished, etc. Also switched to doing things with promises and known-name
+ * methods in WatchmanWatcher, so as much information as possible can be kept in 
+ * the WatchmanClient, ultimately making this the only object listening directly
+ * to watchman.Client, then forwarding appropriately (via the known-name methods) to 
+ * the relevant WatchmanWatcher(s).
+ *
+ * @class WatchmanClient
+ * @param String dir
+ * @param {Object} opts
+ * @public
+ */
+
+function WatchmanClient() {
+
+  // local vars initialized in getClient
+  var _client;
+  var _clientPromise;
+  var _wildmatch;
+  var _relative_root;
+  var _subscriptionId;
+  var _watcherMap;
+
+  var _clientListeners = null;  // direct listeners from WC to watchman.Client.
+
+  // first time init of local vars. Called again in 'onEnd' if we
+  // are reestablishing the connection.
+  clearLocalVars();
+  
+  function getClient() {
+    var self = this;
+    
+    if (!_clientPromise) {
+      _clientPromise = new Promise((resolve, reject) => {
+
+        let client = new watchman.Client();
+
+        // reset the relevant local values
+
+        client.capabilityCheck(
+          {optional: ['wildmatch', 'relative_root']},
+          (error, resp) => {
+            if (error) {
+              reject(error);
+            } else {
+              _wildmatch = resp.capabilities.wildmatch;
+              _relative_root = resp.capabilities.relative_root;
+              _client = client;
+
+              setupClientListeners(self);
+              resolve(self);
+            }
+          }
+        );
+      });
+    }
+
+    return _clientPromise;
+  }
+
+  function clearLocalVars() {
+    if (_client) {
+      _client.end();
+      _client.removeAllListeners();
+    }
+
+    _client = null;
+    _clientPromise = null;
+    _wildmatch = false;
+    _relative_root = false;
+    _subscriptionId = 1;
+    _watcherMap = {};
+  }
+
+  /**
+   * We're the only object directly listening to watchman.Client.
+   * As appropriate, we'll forward to the relevant watcher when
+   * necessary (basically in onSubscription).
+   */
+  function setupClientListeners(self) {
+    _client.on('subscription', onSubscription.bind(self));
+    _client.on('error', onError.bind(self));
+    _client.on('end', onEnd.bind(self));
+  }
+
+  function getSubscription() {
+    let val = 'sane_' + _subscriptionId++;
+    return val;
+  }
+
+  // Return the watcherMap entry for a particular subscription.
+  // If there isn't one, create a new one and assign the watchmanWatcher to it.
+  // Note: should only pass watchmanWatcher during 'subscribe' when the
+  // entry will be created.
+  function createWatcherInfo(watchmanWatcher) {
+    let watcherInfo = {
+      subscription: getSubscription(),
+      watchmanWatcher: watchmanWatcher,           
+      root: null,                      // set during 'watch' or 'watch-project'
+      relativePath: null,              // same
+      since: null,                     // set during 'clock'
+      options: null                    // created and set during 'subscribe'.
+    };
+
+    _watcherMap[watcherInfo.subscription] = watcherInfo;
+
+    return watcherInfo;
+  }
+
+  function getWatcherInfo(subscription) {
+    var watcherInfo = _watcherMap[subscription];
+    return watcherInfo;
+  }
+
+  // Given a watchmanWatcher and a root, issue the correct 'watch'
+  // or 'watch-project' command and handle it with the callback.
+  // Because we're operating in 'sane', we'll keep the results
+  // of the 'watch' or 'watch-project' here.
+  function watch(subscription, root) {
+    var self = this;
+    
+    let promise = new Promise((resolve, reject) => {
+      let watcherInfo = getWatcherInfo(subscription);
+
+      if (_relative_root) { 
+        _client.command(['watch-project', root], (error, resp) => {
+          if (error) {
+            reject(error);
+          } else {
+            watcherInfo.root = resp.watch;
+            watcherInfo.relativePath = resp.relative_path ? resp.relative_path : '';
+            resolve(resp);
+          }
+        });
+      } else {
+        _client.command(['watch', root], (error, resp) => {
+          if (error) {
+            reject(error);
+          } else {
+            watcherInfo.root = root;
+            watcherInfo.relativePath = '';
+            resolve(resp);
+          }
+        });
+      }
+    });
+    
+    return promise;
+  }
+  
+  // Issue the 'clock' command to get the time value for use with the 'since'
+  // option during 'subscribe'.
+  function clock(subscription) {
+    var self = this;
+
+    let promise = new Promise((resolve, reject) => {
+      let watcherInfo = getWatcherInfo(subscription);
+
+      _client.command(['clock', watcherInfo.root], (error, resp) => {
+        if (error) {
+          reject(error);
+        } else {
+          watcherInfo.since = resp.clock;
+          resolve(resp);
+        }
+      });
+    });
+
+    return promise;
+  }
+
+  function subscribe(watchmanWatcher, root) {
+    var self = this;
+
+    let watcherInfo = createWatcherInfo(watchmanWatcher);
+    let subscription = watcherInfo.subscription;
+    
+    let promise = new Promise((resolve, reject) => {
+      watch(subscription, root)
+        .then((resp) => clock(subscription))
+        .then((data) => {
+            let watcherInfo = getWatcherInfo(subscription);
+
+            // create the 'bare' options w/o 'since' or relative_root.
+            // Store in watcherInfo for later use if we need to reset
+            // things after an 'end' caught here.
+            let options = watchmanWatcher.createOptions();  
+            watcherInfo.options = options;
+            
+            // Dup the options object so we can add 'relative_root' and 'since'
+            // and leave the original options object alone. We'll do this again
+            // later if we need to resubscribe after 'end' and reconnect.
+            options = Object.assign({}, options);
+
+            if (_relative_root) {
+              options.relative_root = watcherInfo.relativePath;
+            }
+
+            options.since = watcherInfo.since;
+
+            _client.command(['subscribe',
+                             watcherInfo.root,
+                             subscription,
+                             options],
+                            (error, resp) => {
+                              if (error) {
+                                reject(error);
+                              } else {
+                                resolve(resp);
+                              }
+                            });
+            console.log("For subscription '" + subscription +
+                        "', subscribing against root '" + watcherInfo.root +
+                        "', with relative_root = '" + options.relative_root + "'");
+        })
+        .catch(function(error) {
+          console.error("Caught error in subscribe for watchmanWatcher root " + root);
+          console.error(error);
+          reject(error)
+        });
+    });
+
+    return promise;
+  }
+
+  // Handle the 'subscription' (file change) event
+  function onSubscription(resp) {
+    let watcherInfo = getWatcherInfo(resp.subscription);
+    if (watcherInfo) {
+      watcherInfo.watchmanWatcher.handleChangeEvent(resp);
+    } else {
+      // Note it in the log, but otherwise ignore it
+      console.log("WatchmanClient error - received 'subscription' event for non-existent subscription '" +
+                  resp.subscription + "'");
+    }
+  }
+
+  function onError(error) {
+    console.error('Error from watchman in WatchmanClient. Forwarding to WatchmanWatchers');
+    console.error(error);
+    Object.values(_watcherMap).forEach((watcherInfo) =>
+                                       watcherInfo.watchmanWatcher.handleErrorEvent(error));
+  }
+  
+  function onEnd() {
+    console.warn('[sane.WatchmanClient] Warning: Lost connection to watchman, reconnecting..');
+
+    // Basically do a 'reset' on everything, but without telling the
+    // WatchmanWatchers about it, so they think everything is still working.
+    // We'll assume that things MUST complete successfully for everything to
+    // continue as is, or we'll need to shut everything down by reporting an
+    // error to all WatchmanWatchers.
+
+    // hold the old watcher map so we use it to recreate all subscriptions.
+    let oldWatcherInfos = Object.values(oldWatcherMap);
+
+    clearLocalVars();
+    
+    getClient()
+      .then(
+        (client) => {
+          let promises = oldWatcherInfos.map((watcherInfo) =>
+                                             subscribe(watcherInfo.watchmanWatcher,
+                                                       watcherInfo.watchmanWatcher.root));
+          Promise.all(promises)
+            .then(
+              (resultArray) => {
+                console.log('[sane.WatchmanClient]: Reconnected to watchman');
+              },
+              (error) => {
+                console.error("Reconnected to watchman, but failed to reestablish " +
+                              "at least one subscription, cannot continue");
+                console.error(error);
+                oldWatcherInfos.forEach((watcherInfo) =>
+                                        watcherInfo.watchmanWatcher.handleErrorEvent(error));
+                // XXX not sure whether to clear all _watcherMap instances here,
+                // but basically this client is inconsistent now, since at least one
+                // subscribe failed. 
+              });
+        },
+        (error) => {
+          console.error('Lost connection to watchman, reconnect failed, cannot continue');
+          console.error(error);
+          oldWatcherInfos.forEach((watcherInfo) =>
+                                  watcherInfo.watchmanWatcher.handleErrorEvent(error));
+        });
+  }
+
+  return {
+    get wildmatch() {
+      return _wildmatch;
+    },
+
+    // For quick test
+    onEnd: onEnd,
+    getClient: getClient,
+    subscribe: subscribe
+  }
+}
+
+module.exports = new WatchmanClient()

--- a/src/watchman_client.js
+++ b/src/watchman_client.js
@@ -265,7 +265,7 @@ function WatchmanClient() {
     // error to all WatchmanWatchers.
 
     // hold the old watcher map so we use it to recreate all subscriptions.
-    let oldWatcherInfos = Object.values(oldWatcherMap);
+    let oldWatcherInfos = Object.values(_watcherMap);
 
     clearLocalVars();
     

--- a/src/watchman_client.js
+++ b/src/watchman_client.js
@@ -26,316 +26,351 @@ var watchman = require('fb-watchman');
 
 function WatchmanClient() {
 
-  // local vars initialized in getClient
-  var _client;
-  var _clientPromise;
-  var _wildmatch;
-  var _relative_root;
-  var _subscriptionId;
-  var _watcherMap;
-  var _watchmanPath;
+  // define/clear some local state. The properties will be initialized
+  // in getClient(). This is also called again in _onEnd when
+  // trying to reestablish connection to watchman.Client.
+  this._clearLocalVars(); 
 
-  var _clientListeners = null;  // direct listeners from WC to watchman.Client.
+  this._clientListeners = null;  // direct listeners from here to watchman.Client.
 
-  // first time init of local vars. Called again in 'onEnd' if we
-  // are reestablishing the connection.
-  clearLocalVars();
+  // we may want to call 'getClient()' and return a promise instead later,
+  // but for now we'll assume the WatchmanWatchers will not use wildmatch
+  // until they've done a getClient to retrieve the instance, so the
+  // capabilityCheck call is done.
+  Object.defineProperty(this, 'wildmatch', {
+    get() { return this._wildmatch; }
+  });
+}
+
+/**
+ * Set up the connection to the watchman client. If the optional
+ * value watchmanBinaryPath is passed in AND we're not already in the
+ * middle of setting up the client, use that as the path to the
+ * binary. In either case, return a promise that will be fulfilled
+ * when the client has been set up and capabilities have been returned.
+ */
+WatchmanClient.prototype.getClient = function(watchmanBinaryPath) {
   
-  // Set up the connection to the watchman client. If the optional
-  // value watchmanPath is passed in AND we're not already in the
-  // middle of setting up the client, use that as the path to the
-  // binary. In either case, return a promise that will be fulfilled
-  // when the client has been set up and capabilities have been returned.
-  function getClient(watchmanPath) {
-    var self = this;
-    
-    if (!_clientPromise) {
-      _clientPromise = new Promise((resolve, reject) => {
+  if (!this._clientPromise) {
+    this._clientPromise = new Promise((resolve, reject) => {
 
-        let client = new watchman.Client(watchmanPath ? { watchmanBinaryPath: watchmanPath} : {});
+      let client = new watchman.Client(watchmanBinaryPath
+                                       ? { watchmanBinaryPath: watchmanBinaryPath}
+                                       : {});
 
-        // reset the relevant local values
+      // reset the relevant local values
 
+      try {
         client.capabilityCheck(
           {optional: ['wildmatch', 'relative_root']},
           (error, resp) => {
             if (error) {
               reject(error);
             } else {
-              _wildmatch = resp.capabilities.wildmatch;
-              _relative_root = resp.capabilities.relative_root;
-              _client = client;
+              this._watchmanBinaryPath = watchmanBinaryPath;
+              this._wildmatch = resp.capabilities.wildmatch;
+              this._relative_root = resp.capabilities.relative_root;
+              this._client = client;
 
-              setupClientListeners(self);
-              resolve(self);
+              this._setupClientListeners();
+              resolve(this);
             }
           }
         );
-      });
-    }
-
-    return _clientPromise;
-  }
-
-  function clearLocalVars() {
-    if (_client) {
-      _client.removeAllListeners();
-      _client.end();
-    }
-
-    _client = null;
-    _clientPromise = null;
-    _wildmatch = false;
-    _relative_root = false;
-    _subscriptionId = 1;
-    _watcherMap = {};
-    _watchmanPath = null;
-  }
-
-  /**
-   * This singleton is the only object directly listening to our
-   * watchman.Client. Set up our listeners.
-   */
-  function setupClientListeners(self) {
-    _client.on('subscription', onSubscription.bind(self));
-    _client.on('error', onError.bind(self));
-    _client.on('end', onEnd.bind(self));
-  }
-
-  function getSubscription() {
-    let val = 'sane_' + _subscriptionId++;
-    return val;
-  }
-
-  /**
-   * Create a new watcherInfo entry for the given watchmanWatcher and 
-   * initialize it.
-   */
-  function createWatcherInfo(watchmanWatcher) {
-    let watcherInfo = {
-      subscription: getSubscription(),
-      watchmanWatcher: watchmanWatcher,           
-      root: null,                      // set during 'watch' or 'watch-project'
-      relativePath: null,              // same
-      since: null,                     // set during 'clock'
-      options: null                    // created and set during 'subscribe'.
-    };
-
-    _watcherMap[watcherInfo.subscription] = watcherInfo;
-
-    return watcherInfo;
-  }
-
-  /**
-   * Find an existing watcherInfo instance.
-   */
-  function getWatcherInfo(subscription) {
-    var watcherInfo = _watcherMap[subscription];
-    return watcherInfo;
-  }
-
-  /**
-   * Given a watchmanWatcher and a root, issue the correct 'watch'
-   * or 'watch-project' command and handle it with the callback.
-   * Because we're operating in 'sane', we'll keep the results
-   * of the 'watch' or 'watch-project' here.
-   */
-  function watch(subscription, root) {
-    var self = this;
-    
-    let promise = new Promise((resolve, reject) => {
-      let watcherInfo = getWatcherInfo(subscription);
-
-      if (_relative_root) { 
-        _client.command(['watch-project', root], (error, resp) => {
-          if (error) {
-            reject(error);
-          } else {
-            watcherInfo.root = resp.watch;
-            watcherInfo.relativePath = resp.relative_path ? resp.relative_path : '';
-            resolve(resp);
-          }
-        });
-      } else {
-        _client.command(['watch', root], (error, resp) => {
-          if (error) {
-            reject(error);
-          } else {
-            watcherInfo.root = root;
-            watcherInfo.relativePath = '';
-            resolve(resp);
-          }
-        });
+      } catch (err) {
+        console.error("Client capabilityCheck threw error somehow: " + err);
+        // XXX Do something here to throw an error or reject?
       }
     });
-    
-    return promise;
   }
+
+  return this._clientPromise;
+};
+
+/**
+ * Called from WatchmanWatcher (or this object during reconnect) to create
+ * a watcherInfo entry in our _watcherMap and issue a 'subscribe' to the
+ * watchman.Client, to be handled in this object.
+ */
+WatchmanClient.prototype.subscribe = function(watchmanWatcher, root) {
+
+  let watcherInfo = this._createWatcherInfo(watchmanWatcher);
+  let subscription = watcherInfo.subscription;
   
-  /**
-   * Issue the 'clock' command to get the time value for use with the 'since'
-   * option during 'subscribe'.
-   */
-  function clock(subscription) {
-    var self = this;
-
-    let promise = new Promise((resolve, reject) => {
-      let watcherInfo = getWatcherInfo(subscription);
-
-      _client.command(['clock', watcherInfo.root], (error, resp) => {
-        if (error) {
-          reject(error);
-        } else {
-          watcherInfo.since = resp.clock;
-          resolve(resp);
-        }
-      });
+  return this._watch(subscription, root)
+    .then((resp) => this._clock(subscription))
+    .then((data) => this._subscribe(subscription))
+    .catch((error) => {
+      console.error("Caught error in subscribe for watchmanWatcher root " + root);
+      console.error(error);
+      return Promise.reject(error); // XXX is this right? Or do I just do 'reject(error)'?
     });
+};
 
-    return promise;
-  }
+/**
+ * Remove the information about a specific WatchmanWatcher.
+ * Once done, if no watchers are left, clear the local vars,
+ * which will end the connection to the watchman.Client, too.
+ */
+WatchmanClient.prototype.closeWatcher = function(watchmanWatcher) {
+  let watcherInfos = Object.values(this._watcherMap);
+  let numWatchers = watcherInfos.length;
 
-  /**
-   * Called from WatchmanWatcher (or this object during reconnect) to create
-   * a watcherInfo entry in our _watcherMap and issue a 'subscribe' to the
-   * watchman.Client, to be handled in this object.
-   */
-  function subscribe(watchmanWatcher, root) {
-    var self = this;
-
-    let watcherInfo = createWatcherInfo(watchmanWatcher);
-    let subscription = watcherInfo.subscription;
+  if (numWatchers > 0) {
+    let watcherInfo;
     
-    let promise = new Promise((resolve, reject) => {
-      watch(subscription, root)
-        .then((resp) => clock(subscription))
-        .then((data) => {
-            let watcherInfo = getWatcherInfo(subscription);
+    for (let info of watcherInfos) {
+      if (info.watchmanWatcher === watchmanWatcher) {
+        watcherInfo = info;
+        break;
+      }
+    }
 
-            // create the 'bare' options w/o 'since' or relative_root.
-            // Store in watcherInfo for later use if we need to reset
-            // things after an 'end' caught here.
-            let options = watchmanWatcher.createOptions();  
-            watcherInfo.options = options;
-            
-            // Dup the options object so we can add 'relative_root' and 'since'
-            // and leave the original options object alone. We'll do this again
-            // later if we need to resubscribe after 'end' and reconnect.
-            options = Object.assign({}, options);
-
-            if (_relative_root) {
-              options.relative_root = watcherInfo.relativePath;
-            }
-
-            options.since = watcherInfo.since;
-
-            _client.command(['subscribe',
-                             watcherInfo.root,
-                             subscription,
-                             options],
-                            (error, resp) => {
-                              if (error) {
-                                reject(error);
-                              } else {
-                                resolve(resp);
-                              }
-                            });
-            console.log("For subscription '" + subscription +
-                        "', subscribing against root '" + watcherInfo.root +
-                        "', with relative_root = '" + options.relative_root + "'");
-        })
-        .catch(function(error) {
-          console.error("Caught error in subscribe for watchmanWatcher root " + root);
-          console.error(error);
-          reject(error)
-        });
-    });
-
-    return promise;
-  }
-
-  /**
-   * Handle the 'subscription' (file change) event, by calling the 
-   * handler on the relevant WatchmanWatcher.
-   */
-  function onSubscription(resp) {
-    let watcherInfo = getWatcherInfo(resp.subscription);
     if (watcherInfo) {
-      watcherInfo.watchmanWatcher.handleChangeEvent(resp);
-    } else {
-      // Note it in the log, but otherwise ignore it
-      console.log("WatchmanClient error - received 'subscription' event " +
-                  "for non-existent subscription '" +
-                  resp.subscription + "'");
+      delete this._watcherMap[watcherInfo.subscription];
+
+      numWatchers--;
+
+      if (numWatchers === 0) {
+        this._clearLocalVars();
+      }
     }
   }
+};
 
-  /**
-   * Handle the 'error' event by forwarding to the
-   * handler on the relevant WatchmanWatcher.
-   */
-  function onError(error) {
-    console.error('Error from watchman in WatchmanClient. Forwarding to WatchmanWatchers');
-    console.error(error);
-    Object.values(_watcherMap).forEach((watcherInfo) =>
-                                       watcherInfo.watchmanWatcher.handleErrorEvent(error));
-  }
-  
-  /**
-   * Handle the 'end' event by creating a new watchman.Client and
-   * attempting to resubscribe all the existing subscriptions, but
-   * without notifying the WatchmanWatchers about it. They should
-   * not be aware the connection was lost and recreated.
-   * If something goes wrong during any part of the reconnect/setup,
-   * call the error handler on each existing WatchmanWatcher.
-   */
-  function onEnd() {
-    console.warn('[sane.WatchmanClient] Warning: Lost connection to watchman, reconnecting..');
-
-    // hold the old watcher map so we use it to recreate all subscriptions.
-    let oldWatcherInfos = Object.values(_watcherMap);
-    let watchmanPath = _watchmanPath;
-
-    clearLocalVars();
-    
-    getClient(watchmanPath)
-      .then(
-        (client) => {
-          let promises = oldWatcherInfos.map((watcherInfo) =>
-                                             subscribe(watcherInfo.watchmanWatcher,
-                                                       watcherInfo.watchmanWatcher.root));
-          Promise.all(promises)
-            .then(
-              (resultArray) => {
-                console.log('[sane.WatchmanClient]: Reconnected to watchman');
-              },
-              (error) => {
-                console.error("Reconnected to watchman, but failed to reestablish " +
-                              "at least one subscription, cannot continue");
-                console.error(error);
-                oldWatcherInfos.forEach((watcherInfo) =>
-                                        watcherInfo.watchmanWatcher.handleErrorEvent(error));
-                // XXX not sure whether to clear all _watcherMap instances here,
-                // but basically this client is inconsistent now, since at least one
-                // subscribe failed. 
-              });
-        },
-        (error) => {
-          console.error('Lost connection to watchman, reconnect failed, cannot continue');
-          console.error(error);
-          oldWatcherInfos.forEach((watcherInfo) =>
-                                  watcherInfo.watchmanWatcher.handleErrorEvent(error));
-        });
+/**
+ * Clear out local state at the beginning and if we end up
+ * getting disconnected and try to reconnect.
+ */
+WatchmanClient.prototype._clearLocalVars = function() {
+  if (this._client) {
+    this._client.removeAllListeners();
+    this._client.end();
   }
 
-  return {
-    get wildmatch() {
-      return _wildmatch;
-    },
+  this._client = null;
+  this._clientPromise = null;
+  this._wildmatch = false;
+  this._relative_root = false;
+  this._subscriptionId = 1;
+  this._watcherMap = {};
+  this._watchmanBinaryPath = null;
+};
 
-    getClient: getClient,
-    subscribe: subscribe
-  }
+/**
+ * This singleton is the only object directly listening to our
+ * watchman.Client. Set up our listeners.
+ */
+WatchmanClient.prototype._setupClientListeners = function() {
+  this._client.on('subscription', this._onSubscription.bind(this));
+  this._client.on('error', this._onError.bind(this));
+  this._client.on('end', this._onEnd.bind(this));
+};
+
+WatchmanClient.prototype._getSubscription = function() {
+  let val = 'sane_' + this._subscriptionId++;
+  return val;
+};
+
+/**
+ * Create a new watcherInfo entry for the given watchmanWatcher and 
+ * initialize it.
+ */
+WatchmanClient.prototype._createWatcherInfo = function(watchmanWatcher) {
+  let watcherInfo = {
+    subscription: this._getSubscription(),
+    watchmanWatcher: watchmanWatcher,           
+    root: null,                      // set during 'watch' or 'watch-project'
+    relativePath: null,              // same
+    since: null,                     // set during 'clock'
+    options: null                    // created and set during 'subscribe'.
+  };
+
+  this._watcherMap[watcherInfo.subscription] = watcherInfo;
+
+  return watcherInfo;
+};
+
+/**
+ * Find an existing watcherInfo instance.
+ */
+WatchmanClient.prototype._getWatcherInfo = function(subscription) {
+  var watcherInfo = this._watcherMap[subscription];
+  return watcherInfo;
 }
+
+/**
+ * Given a watchmanWatcher and a root, issue the correct 'watch'
+ * or 'watch-project' command and handle it with the callback.
+ * Because we're operating in 'sane', we'll keep the results
+ * of the 'watch' or 'watch-project' here.
+ */
+WatchmanClient.prototype._watch = function(subscription, root) {
+  
+  let promise = new Promise((resolve, reject) => {
+    let watcherInfo = this._getWatcherInfo(subscription);
+
+    if (this._relative_root) { 
+      this._client.command(['watch-project', root],
+                           (error, resp) => {
+                             if (error) {
+                               reject(error);
+                             } else {
+                               watcherInfo.root = resp.watch;
+                               watcherInfo.relativePath = resp.relative_path
+                                 ? resp.relative_path
+                                 : '';
+                               resolve(resp);
+                             }
+                           });
+    } else {
+      this._client.command(['watch', root],
+                           (error, resp) => {
+                             if (error) {
+                               reject(error);
+                             } else {
+                               watcherInfo.root = root;
+                               watcherInfo.relativePath = '';
+                               resolve(resp);
+                             }
+                           });
+    }
+  });
+  
+  return promise;
+};
+  
+/**
+ * Issue the 'clock' command to get the time value for use with the 'since'
+ * option during 'subscribe'.
+ */
+WatchmanClient.prototype._clock = function(subscription) {
+  let promise = new Promise((resolve, reject) => {
+    let watcherInfo = this._getWatcherInfo(subscription);
+
+    this._client.command(['clock', watcherInfo.root],
+                         (error, resp) => {
+                           if (error) {
+                             reject(error);
+                           } else {
+                             watcherInfo.since = resp.clock;
+                             resolve(resp);
+                           }
+                         });
+  });
+
+  return promise;
+};
+
+/** 
+ * Do the internal handling of calling the watchman.Client for
+ * a subscription.
+ */
+WatchmanClient.prototype._subscribe = function(subscription) {
+  let promise = new Promise((resolve, reject) => {
+    let watcherInfo = this._getWatcherInfo(subscription);
+
+    // create the 'bare' options w/o 'since' or relative_root.
+    // Store in watcherInfo for later use if we need to reset
+    // things after an 'end' caught here.
+    let options = watcherInfo.watchmanWatcher.createOptions();  
+    watcherInfo.options = options;
+    
+    // Dup the options object so we can add 'relative_root' and 'since'
+    // and leave the original options object alone. We'll do this again
+    // later if we need to resubscribe after 'end' and reconnect.
+    options = Object.assign({}, options);
+
+    if (this._relative_root) {
+      options.relative_root = watcherInfo.relativePath;
+    }
+
+    options.since = watcherInfo.since;
+
+    this._client.command(['subscribe', watcherInfo.root, subscription, options],
+                         (error, resp) => {
+                           if (error) {
+                             reject(error);
+                           } else {
+                             resolve(resp);
+                           }
+                         });
+  });
+  
+  return promise;
+}
+
+/**
+ * Handle the 'subscription' (file change) event, by calling the 
+ * handler on the relevant WatchmanWatcher.
+ */
+WatchmanClient.prototype._onSubscription = function(resp) {
+  let watcherInfo = this._getWatcherInfo(resp.subscription);
+  if (watcherInfo) {
+    watcherInfo.watchmanWatcher.handleChangeEvent(resp);
+  } else {
+    // Note it in the log, but otherwise ignore it
+    console.error("WatchmanClient error - received 'subscription' event " +
+                  "for non-existent subscription '" +
+                  resp.subscription + "'");
+  }
+};
+
+/**
+ * Handle the 'error' event by forwarding to the
+ * handler on the relevant WatchmanWatcher.
+ */
+WatchmanClient.prototype._onError = function(error) {
+  Object.values(this._watcherMap).forEach((watcherInfo) =>
+                                          watcherInfo.watchmanWatcher.handleErrorEvent(error));
+};
+
+/**
+ * Handle the 'end' event by creating a new watchman.Client and
+ * attempting to resubscribe all the existing subscriptions, but
+ * without notifying the WatchmanWatchers about it. They should
+ * not be aware the connection was lost and recreated.
+ * If something goes wrong during any part of the reconnect/setup,
+ * call the error handler on each existing WatchmanWatcher.
+ */
+WatchmanClient.prototype._onEnd = function() {
+  console.warn('[sane.WatchmanClient] Warning: Lost connection to watchman, reconnecting..');
+
+  // Hold the old watcher map so we use it to recreate all subscriptions.
+  // Hold the old watchmanBinaryPath because it should not have changed.
+  let oldWatcherInfos = Object.values(this._watcherMap);
+  let watchmanBinaryPath = this._watchmanBinaryPath;
+
+  clearLocalVars();
+  
+  this.getClient(watchmanBinaryPath)
+    .then(
+      (client) => {
+        let promises = oldWatcherInfos.map((watcherInfo) =>
+                                           subscribe(watcherInfo.watchmanWatcher,
+                                                     watcherInfo.watchmanWatcher.root));
+        Promise.all(promises)
+          .then(
+            (resultArray) => {
+              console.log('[sane.WatchmanClient]: Reconnected to watchman');
+            },
+            (error) => {
+              console.error("Reconnected to watchman, but failed to reestablish " +
+                            "at least one subscription, cannot continue");
+              console.error(error);
+              oldWatcherInfos.forEach((watcherInfo) =>
+                                      watcherInfo.watchmanWatcher.handleErrorEvent(error));
+              // XXX not sure whether to clear all _watcherMap instances here,
+              // but basically this client is inconsistent now, since at least one
+              // subscribe failed. 
+            });
+      },
+      (error) => {
+        console.error('Lost connection to watchman, reconnect failed, cannot continue');
+        console.error(error);
+        oldWatcherInfos.forEach((watcherInfo) =>
+                                watcherInfo.watchmanWatcher.handleErrorEvent(error));
+      });
+};
 
 module.exports = new WatchmanClient()

--- a/src/watchman_client.js
+++ b/src/watchman_client.js
@@ -64,11 +64,8 @@ WatchmanClient.prototype.subscribe = function(watchmanWatcher, root) {
       return this._watch(subscription, root);
     })
     .then((resp) => this._clock(subscription))
-    .then((data) => this._subscribe(subscription))
-    .catch((error) => {
-      console.error("Failed creating subscription for root " + root);
-      throw error;
-    });
+    .then((data) => this._subscribe(subscription));
+   // Note: callers are responsible for noting any subscription failure.
 };
 
 /**

--- a/src/watchman_client.js
+++ b/src/watchman_client.js
@@ -153,7 +153,7 @@ WatchmanClient.prototype._clearLocalVars = function() {
   this._wildmatch = false;
   this._relative_root = false;
   this._subscriptionId = 1;
-  this._watcherMap = {};
+  this._watcherMap = Object.create(null);
   this._watchmanBinaryPath = null;
 };
 

--- a/src/watchman_watcher.js
+++ b/src/watchman_watcher.js
@@ -183,8 +183,6 @@ WatchmanWatcher.prototype.handleFileChange = function(changeDescriptor) {
       // Change event on dirs are mostly useless.
       if (!(eventType === CHANGE_EVENT && stat.isDirectory())) {
         self.emitEvent(eventType, relativePath, self.root, stat);
-        // For quick test
-        self.client.onEnd();
       }
     });
   }

--- a/src/watchman_watcher.js
+++ b/src/watchman_watcher.js
@@ -49,20 +49,20 @@ WatchmanWatcher.prototype._init = function() {
     this._client = null;
   }
 
-  // Create/setup the WatchmanClient singleton, passing in our watchmanPath
-  // if we have one (optional). Then subscribe, which will do the appropriate
-  // setup so that we will receive calls to handleChangeEvent when files change.
-  watchmanClient.getClient(this.watchmanPath)
-    .then((client) => {
-      this._client = client;
-
-      return this._client.subscribe(this, this.root)
-        .then((resp) => {
-          this._handleWarning(resp);
-          this.emit('ready');
-        });
-    })
-    .catch((error) => this._handleError(error));
+  // Get the WatchmanClient instance corresponding to our watchmanPath (or nothing).
+  // Then subscribe, which will do the appropriate setup so that we will receive
+  // calls to handleChangeEvent when files change.
+  this._client = watchmanClient.getInstance(this.watchmanPath);
+  
+  return this._client.subscribe(this, this.root)
+    .then(
+      (resp) => {
+        this._handleWarning(resp);
+        this.emit('ready');
+      },
+      (error) => {
+        this._handleError(error);
+      });
 };
 
 /**


### PR DESCRIPTION
At LinkedIn, we're running into an issue with using watchman with sane for a large ember project (basically the LinkedIn.com web UI application). The application has many thousands of files, in hundreds of directories, and as it's being built and served using broccoli, it creates a huge number of 'sane' instances that result in WatchmanWatcher instances. Each of those instances is connecting to watchman by creating a watchman.Client, and that's causing watchman a lot of issues with too many clients and connections to the watchman daemon.

@stefanpenner and the watchman implementor at Facebook both suggested that the general idea with watchman is to use one watchman.Client per process, not one per watched root. This PR is to provide that, and do a bunch of optimization to simplify the WatchmanWatcher class as well. Specifically:

* Create a singleton WatchmanClient JS class in sane/src alongside WatchmanWatcher.
* Have the singleton hide a single instance of watchman.Client, rather than providing access to it to every WatchmanWatcher.
* Have the singleton be the only object actually registered as a listener for the watchman.Client, and have those listeners forward appropriately to the WatchmanWatcher when necessary.
* Have the singleton send a 'capabilityCheck' to the single watchman.Client when first contacted by a WatchmanWatcher, and delay responding until the capabilityCheck is completed. This means only a single capabilityCheck needs to be done, and the data can be kept in the singleton.
* To implement the "wait for capabilityCheck to be done", the WatchmanClient is not an EventEmitter. Its methods return promises, and the WatchmanWatcher now does its handling in promise.then(success,fail) code.
* The WatchmanWatchers really don't need to know about the difference between 'watch' and 'watch-project', so that is also hidden in the WatchmanClient. This means the WatchmanWatcher can just store its root in 'this.root' as before, it doesn't have to keep watchProjectInfo. Instead, the WatchmanClient now keeps a map of subscription name to "watcherInfo" instance data, which includes things like the WatchmanWatcher instance, the subscription name, the 'root' and 'relativePath' data for that watcher, etc. When using 'watch' (because relative_root isn't supported), the root is set to the subscription root and the relativePath is set to the empty string, so we are always using both when calculating paths in WatchmanClient.
* The WatchmanClient public API now only includes 3 methods (may be 4 soon - see below):
    * wildmatch - a getter property to return the value of the 'wildmatch' capability
    * getClient - the method to initially get the singleton WatchmanClient instance, but only after it has been able to set the wildmatch and relative_root values locally. The function returns a promise that resolves to the WatchmanClient instance.
    * subscribe - called by the WatchmanWatcher to subscribe for a particular root. This internally then does a 'watch' or 'watch-project', a 'clock', and finally issues the 'subscribe' command to the real watchman.Client. It returns a promise so it can return any error that occurs during this setup.
    * The probable fourth method is 'close', since the existing WatchmanWatcher calls this on the watchman.Client in the original version.
* The WatchmanClient is now the direct listener for 'subscription' messages, and it uses the unique subscription ID (created in WatchmanClient) to get the associated WatchmanWatcher, then calls 'handleChangeEvent' directly on the WatchmanWatcher, rather than trying to emit a message.
* The WatchmanClient is now also the direct listener for 'error' events. Whenever one occurs it prints a message to the console (and a second that is the actual error), then calls 'handleErrorEvent' directly on each registered WatchmanWatcher. It does this rather than becoming an EventEmitter and emitting a single event because it just seemed simpler.
* The WatchmanClient is now also the direct listener for 'end' events. There is sufficient information in the 'watcher info' data in WatchmanClient to close things, create a new watchman.Client, and recreate all the WatchmanWatcher subscriptions - the WatchmanWatchers don't even need to know that the re-connect has been done. If there's an error during reconnecting, handleErrorEvent() is called on all registered WatchmanWatcher instances.
* One change that the above 'end' and 'subscribe' handling required is a new WatchmanWatcher method 'createOptions'. This is called during subscribe to get the options for the watcher, since the value depends on wildmatch, which may change after an 'end' and reconnect.
* I also moved the options.since and options.relative_root processing into 'subscribe', so the WatchmanWatchers didn't need to deal with them.