### PR TITLE
adding handler to clear local state on exit using capture-exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "anymatch": "^2.0.0",
+    "capture-exit": "^1.2.0",
     "exec-sh": "^0.2.0",
     "fb-watchman": "^2.0.0",
     "micromatch": "^3.1.4",


### PR DESCRIPTION
This is a follow on to the original PR (https://github.com/amasad/sane/pull/113), to implement the last part of handling a shutdown from the node side. @stefanpenner noticed that the exit handling had not been resolved since February.