### PR TITLE
Enables Watchexec as a sane watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Sane aims to be fast, small, and reliable file system watcher. It does that by:
 * Maintains a consistent API across different platforms
 * Where `fs.watch` is not reliable you have the choice of using the following alternatives:
   * [the facebook watchman library](https://facebook.github.io/watchman/)
+  * [the watchexec library](https://github.com/watchexec/watchexec)
   * polling
 
 ## Install
@@ -52,11 +53,13 @@ options:
 * `poll`: puts the watcher in polling mode. Under the hood that means `fs.watchFile`.
 * `watchman`: makes the watcher use [watchman](https://facebook.github.io/watchman/).
 * `watchmanPath`: sets a custom path for `watchman` binary.
+* `watchexec`: makes the watcher use [watchexec](https://github.com/watchexec/watchexec).
 * `dot`: enables watching files/directories that start with a dot.
 * `ignored`: a glob, regex, function, or array of any combination.
 
 For the glob pattern documentation, see [micromatch](https://github.com/micromatch/micromatch).
 If you choose to use `watchman` you'll have to [install watchman yourself](https://facebook.github.io/watchman/docs/install.html)).
+If you choose to use `watchexec` you'll have to [install watchexec yourself](https://github.com/watchexec/watchexec)).
 For the ignored options, see [anymatch](https://github.com/es128/anymatch).
 
 ### sane.NodeWatcher(dir, options)
@@ -67,17 +70,21 @@ The default watcher class. Uses `fs.watch` under the hood, and takes the same op
 
 The watchman watcher class. Takes the same options as `sane(dir, options)`.
 
+### sane.Watchexec(dir, options)
+
+The watchexec watcher class. Takes the same options as `sane(dir, options)`.
+
 ### sane.PollWatcher(dir, options)
 
 The polling watcher class. Takes the same options as `sane(dir, options)` with the addition of:
 
 * interval: indicates how often the files should be polled. (passed to fs.watchFile)
 
-### sane.{Node|Watchman|Poll}Watcher#close
+### sane.{Node|Watchman|Watchexec|Poll}Watcher#close
 
 Stops watching.
 
-### sane.{Node|Watchman|Poll}Watcher events
+### sane.{Node|Watchman|Watchexec|Poll}Watcher events
 
 Emits the following events:
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const NodeWatcher = require('./src/node_watcher');
 const PollWatcher = require('./src/poll_watcher');
 const WatchmanWatcher = require('./src/watchman_watcher');
+const WatchexecWatcher = require('./src/watchexec_watcher');
 const FSEventsWatcher = require('./src/fsevents_watcher');
 
 function sane(dir, options) {
@@ -14,6 +15,8 @@ function sane(dir, options) {
     return new PollWatcher(dir, options);
   } else if (options.watchman) {
     return new WatchmanWatcher(dir, options);
+  } else if (options.watchexec) {
+    return new WatchexecWatcher(dir, options);
   } else if (options.fsevents) {
     return new FSEventsWatcher(dir, options);
   } else {
@@ -25,4 +28,5 @@ module.exports = sane;
 sane.NodeWatcher = NodeWatcher;
 sane.PollWatcher = PollWatcher;
 sane.WatchmanWatcher = WatchmanWatcher;
+sane.WatchexecWatcher = WatchexecWatcher;
 sane.FSEventsWatcher = FSEventsWatcher;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fb-watchman": "^2.0.0",
     "micromatch": "^3.1.4",
     "minimist": "^1.1.1",
+    "util.promisify": "^1.0.0",
     "walker": "~1.0.5",
     "watch": "~0.18.0"
   },

--- a/src/watchexec_client.js
+++ b/src/watchexec_client.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const {
+  WATCHEXEC_COMMON_PATH,
+  WATCHEXEC_WRITTEN_PATH,
+  WATCHEXEC_RENAMED_PATH,
+  WATCHEXEC_REMOVED_PATH,
+  WATCHEXEC_CREATED_PATH,
+} = process.env;
+
+const { EOL } = require('os');
+
+function toFullPath(arr) {
+  return arr.map(path => (WATCHEXEC_COMMON_PATH || '') + path);
+}
+
+function withPrefixes(prefixes) {
+  return function withPrefix(arr, i) {
+    return arr.map(str => {
+      return `${prefixes[i]} ${str}`;
+    });
+  };
+}
+
+let allPrefixes = ['write', 'rename', 'remove', 'create'];
+let events = [
+  WATCHEXEC_WRITTEN_PATH,
+  WATCHEXEC_RENAMED_PATH,
+  WATCHEXEC_REMOVED_PATH,
+  WATCHEXEC_CREATED_PATH,
+];
+
+let currentPrefixes = events.map((l, i) => l && allPrefixes[i]).filter(Boolean);
+
+let message = events
+  .filter(Boolean)
+  .map(str => str.split(':'))
+  .map(toFullPath)
+  .map(withPrefixes(currentPrefixes))
+  .reduce((e, memo) => memo.concat(e), [])
+  .join(EOL);
+
+message && console.log(message);

--- a/src/watchexec_watcher.js
+++ b/src/watchexec_watcher.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const { spawn } = require('child_process');
+const promisify = require('util.promisify');
+
+const fs = require('fs');
+const path = require('path');
+const common = require('./common');
+const EventEmitter = require('events').EventEmitter;
+
+const { EOL } = require('os');
+
+const statPromise = promisify(fs.stat);
+
+/**
+ * Constants
+ */
+
+const CHANGE_EVENT = common.CHANGE_EVENT;
+const DELETE_EVENT = common.DELETE_EVENT;
+const ADD_EVENT = common.ADD_EVENT;
+const ALL_EVENT = common.ALL_EVENT;
+
+/**
+ * Export `WatchexecWatcher` class.
+ * Watches `dir`.
+ *
+ * @class WatchexecWatcher
+ * @param String dir
+ * @param {Object} opts
+ * @public
+ */
+
+module.exports = class WatchexecWatcher extends EventEmitter {
+  constructor(dir, opts) {
+    super();
+
+    common.assignOptions(this, opts);
+
+    this.root = path.resolve(dir);
+
+    this._process = spawn(
+      'watchexec',
+      ['-n', '--', 'node', __dirname + '/watchexec_client.js'],
+      { cwd: dir }
+    );
+
+    this._process.stdout.on('data', data => {
+      data
+        .toString()
+        .split(EOL)
+        .filter(Boolean)
+        .map(line => {
+          const [, command, path] = [
+            ...line.match(/(rename|write|remove|create)\s(.+)/),
+          ];
+          return [command, path];
+        })
+        .forEach(([command, file]) => {
+          let typeMap = {
+            rename: CHANGE_EVENT,
+            write: CHANGE_EVENT,
+            remove: DELETE_EVENT,
+            create: ADD_EVENT,
+          };
+          let statPromise;
+          let type = typeMap[command];
+          if (type === DELETE_EVENT) {
+            statPromise = Promise.resolve();
+          } else {
+            statPromise = this._statPromise(file);
+          }
+          statPromise.then(stat => {
+            this.emitEvent(type, path.relative(this.root, file), stat);
+          });
+        });
+    });
+  }
+
+  _statPromise(fullPath) {
+    console.log('FULL_PATH', fullPath);
+    return statPromise(fullPath).catch(() => undefined);
+  }
+
+  close(callback) {
+    this.removeAllListeners();
+    this._process && !this._process.killed && this._process.kill();
+    if (typeof callback === 'function') {
+      setImmediate(callback.bind(null, null, true));
+    }
+  }
+
+  /**
+   * Initiate the polling file watcher with the event emitter passed from
+   * `watch.watchTree`.
+   *
+   * @param {EventEmitter} monitor
+   * @public
+   */
+
+  init(monitor) {
+    this.watched = monitor.files;
+    monitor.on('changed', this.emitEvent.bind(this, CHANGE_EVENT));
+    monitor.on('removed', this.emitEvent.bind(this, DELETE_EVENT));
+    monitor.on('created', this.emitEvent.bind(this, ADD_EVENT));
+    // 1 second wait because mtime is second-based.
+    setTimeout(this.emit.bind(this, 'ready'), 1000);
+  }
+
+  /**
+   * Transform and emit an event comming from the poller.
+   *
+   * @param {EventEmitter} monitor
+   * @public
+   */
+
+  emitEvent(type, file, stat) {
+    console.log(type, file, !!stat);
+    this.emit(type, file, this.root, stat);
+    this.emit(ALL_EVENT, type, file, this.root, stat);
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -32,9 +32,15 @@ describe('sane in watchman mode with offset project', function() {
   harness.call(this, { watchman: true, offset: true });
 });
 
+describe('sane in watchexec mode', function() {
+  harness.call(this, { watchexec: true });
+});
+
 function getWatcherClass(mode) {
   if (mode.watchman) {
     return sane.WatchmanWatcher;
+  } else if (mode.WatchexecWatcher) {
+    return sane.WatchexecWatcher;
   } else if (mode.poll) {
     return sane.PollWatcher;
   } else if (mode.fsevents) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,6 +314,12 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  dependencies:
+    object-keys "^1.0.12"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -362,6 +368,24 @@ doctrine@^2.0.0:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
+
+es-abstract@^1.5.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.45"
@@ -624,6 +648,10 @@ fsevents@^1.2.3:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -734,6 +762,12 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
+has@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
+
 iconv-lite@^0.4.4:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
@@ -807,6 +841,10 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -818,6 +856,10 @@ is-data-descriptor@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -901,9 +943,19 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -1207,11 +1259,22 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -1696,6 +1759,13 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
It has been recently suggested in the Ember Discord that
[Watchexec](https://github.com/watchexec/watchexec) would be a
valuable addition to the list of sane watchers.

This PR is an initial attempt towards this.

Disclosure: The end goal here is to be able to test (and propose)
watchexec as a watcher for ember-cli. So this PR will be followed
by 2 (ridiculously small) PR to the following projects:
* watch-detector
* ember-cli

I'd very much like your input on this.

Hope you'll like it, as well as the PR.