### PR TITLE
Ignore stat failures for ENOENT in Watchexec watcher.

### DIFF
--- a/src/watchexec_watcher.js
+++ b/src/watchexec_watcher.js
@@ -49,7 +49,13 @@ function _messageHandler(data) {
       if (type === DELETE_EVENT) {
         stat = null;
       } else {
-        stat = statSync(file);
+        try {
+          stat = statSync(file);
+        } catch(e) {
+          // There is likely a delete coming down the pipe.
+          if (e.code === 'ENOENT') return;
+          throw e;
+        }
       }
       this.emitEvent(type, path.relative(this.root, file), stat);
     });

--- a/src/watchexec_watcher.js
+++ b/src/watchexec_watcher.js
@@ -51,9 +51,11 @@ function _messageHandler(data) {
       } else {
         try {
           stat = statSync(file);
-        } catch(e) {
+        } catch (e) {
           // There is likely a delete coming down the pipe.
-          if (e.code === 'ENOENT') return;
+          if (e.code === 'ENOENT') {
+            return;
+          }
           throw e;
         }
       }


### PR DESCRIPTION
Assuming this is due to a create-delete race (in my case).

The statSync may fail if the file has been removed, imo there's no benefit to this throwing, so ignore the event (and assume a delete event will arrive soon).