### PR TITLE
Removing engines directive from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
     "rimraf": "~2.2.6",
     "tmp": "0.0.27"
   },
-  "engines": {
-    "node": "6.* || 8.* || >= 10.*"
-  },
   "bugs": {
     "url": "https://github.com/amasad/sane/issues"
   },


### PR DESCRIPTION
it was raising an error on a docker build with node 11.11