### PR TITLE
minimist update

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "execa": "^1.0.0",
     "fb-watchman": "^2.0.0",
     "micromatch": "^3.1.4",
-    "minimist": "^1.1.1",
+    "minimist": "^1.2.3",
     "walker": "~1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
minimist  before 1.2.2 could be tricked into adding or modifying properties of  Object.prototype using a "constructor" or "__proto__" payload.



