### PR TITLE
[PATCH] 5.0.1 Fix unmatched package.json version and published version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sane",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Sane aims to be fast, small, and reliable file system watcher.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
- I ran `npm version major` after manually editing package.json with version 5.0.0, this bumped version to 6.0.0
- I then manually edited package.json again to 5.0.0
- I then ran npm publish, not realizing that this would cause a discrepancy with npm, where the stated version on https://www.npmjs.com/package/sane was '5.0.0', but npm install would list version in dependencies as 6.0.0

To correct, I ran `npm version 5.0.1` and published, since you cannot republish an old version.
This may cause an issue with the next major version, and could require the next major version to start at 6.0.1